### PR TITLE
feat: カードデータ構造とデッキシステムの実装

### DIFF
--- a/frontend/src/game/deck.test.ts
+++ b/frontend/src/game/deck.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { HAND_LIMIT, INITIAL_DECK, TOTAL_DECK_SIZE } from "../constants";
+import { RNG } from "../utils/rng";
+import {
+	createInitialDeck,
+	createInitialDeckState,
+	discardHand,
+	drawCards,
+	playCard,
+	resetCardIdCounter,
+	reshuffleDeck,
+} from "./deck";
+
+describe("deck", () => {
+	const SEED = 42;
+
+	beforeEach(() => {
+		resetCardIdCounter();
+	});
+
+	describe("createInitialDeck", () => {
+		it("合計18枚のカードを生成する", () => {
+			const rng = new RNG(SEED);
+			const deck = createInitialDeck(rng);
+			expect(deck).toHaveLength(TOTAL_DECK_SIZE);
+		});
+
+		it("移動カード8枚、攻撃カード8枚、待機カード2枚を含む", () => {
+			const rng = new RNG(SEED);
+			const deck = createInitialDeck(rng);
+			const moveCards = deck.filter((c) => c.type === "move");
+			const attackCards = deck.filter((c) => c.type === "attack");
+			const waitCards = deck.filter((c) => c.type === "wait");
+			expect(moveCards).toHaveLength(INITIAL_DECK.moveCards);
+			expect(attackCards).toHaveLength(INITIAL_DECK.attackCards);
+			expect(waitCards).toHaveLength(INITIAL_DECK.waitCards);
+		});
+
+		it("各カードに一意のIDを持つ", () => {
+			const rng = new RNG(SEED);
+			const deck = createInitialDeck(rng);
+			const ids = deck.map((c) => c.id);
+			expect(new Set(ids).size).toBe(ids.length);
+		});
+
+		it("同じシードで同じ順序のデッキを生成する", () => {
+			const rng1 = new RNG(SEED);
+			const deck1 = createInitialDeck(rng1);
+			resetCardIdCounter();
+			const rng2 = new RNG(SEED);
+			const deck2 = createInitialDeck(rng2);
+			expect(deck1.map((c) => c.type)).toEqual(deck2.map((c) => c.type));
+		});
+	});
+
+	describe("createInitialDeckState", () => {
+		it("山札にデッキをセットし、手札・捨て札は空", () => {
+			const rng = new RNG(SEED);
+			const state = createInitialDeckState(rng);
+			expect(state.drawPile).toHaveLength(TOTAL_DECK_SIZE);
+			expect(state.hand).toHaveLength(0);
+			expect(state.discardPile).toHaveLength(0);
+		});
+	});
+
+	describe("drawCards", () => {
+		it("手札上限まで山札からカードを引く", () => {
+			const rng = new RNG(SEED);
+			const deck = createInitialDeckState(rng);
+			const result = drawCards(deck, rng);
+			expect(result.hand).toHaveLength(HAND_LIMIT);
+			expect(result.drawPile).toHaveLength(TOTAL_DECK_SIZE - HAND_LIMIT);
+		});
+
+		it("指定枚数だけカードを引く", () => {
+			const rng = new RNG(SEED);
+			const deck = createInitialDeckState(rng);
+			const result = drawCards(deck, rng, 3);
+			expect(result.hand).toHaveLength(3);
+			expect(result.drawPile).toHaveLength(TOTAL_DECK_SIZE - 3);
+		});
+
+		it("山札が不足する場合は捨て札をシャッフルして山札に戻す", () => {
+			const rng = new RNG(SEED);
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [{ id: "card-1", type: "move" }],
+				hand: [],
+				discardPile: [
+					{ id: "card-2", type: "attack" },
+					{ id: "card-3", type: "attack" },
+					{ id: "card-4", type: "wait" },
+				],
+			};
+			const result = drawCards(deck, rng, 3);
+			expect(result.hand).toHaveLength(3);
+			expect(result.drawPile).toHaveLength(1);
+			expect(result.discardPile).toHaveLength(0);
+		});
+
+		it("山札・捨て札の合計が引く枚数に満たない場合は引ける枚数だけ引く", () => {
+			const rng = new RNG(SEED);
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [{ id: "card-1", type: "move" }],
+				hand: [],
+				discardPile: [{ id: "card-2", type: "attack" }],
+			};
+			const result = drawCards(deck, rng, 5);
+			expect(result.hand).toHaveLength(2);
+		});
+
+		it("手札が既にある場合は上限まで補充する", () => {
+			const rng = new RNG(SEED);
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: createInitialDeck(new RNG(SEED)),
+				hand: [
+					{ id: "card-existing-1", type: "move" },
+					{ id: "card-existing-2", type: "attack" },
+				],
+				discardPile: [],
+			};
+			resetCardIdCounter();
+			const result = drawCards(deck, rng);
+			expect(result.hand).toHaveLength(HAND_LIMIT);
+		});
+	});
+
+	describe("playCard", () => {
+		it("手札からカードを捨て札に移動する", () => {
+			const card = { id: "card-1", type: "move" as const };
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [],
+				hand: [card, { id: "card-2", type: "attack" }],
+				discardPile: [],
+			};
+			const result = playCard(deck, "card-1");
+			expect(result.hand).toHaveLength(1);
+			expect(result.hand[0].id).toBe("card-2");
+			expect(result.discardPile).toHaveLength(1);
+			expect(result.discardPile[0].id).toBe("card-1");
+		});
+
+		it("存在しないカードIDを指定した場合はデッキを変更しない", () => {
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [],
+				hand: [{ id: "card-1", type: "move" }],
+				discardPile: [],
+			};
+			const result = playCard(deck, "nonexistent");
+			expect(result).toBe(deck);
+		});
+	});
+
+	describe("discardHand", () => {
+		it("手札をすべて捨て札に移動する", () => {
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [{ id: "card-3", type: "wait" }],
+				hand: [
+					{ id: "card-1", type: "move" },
+					{ id: "card-2", type: "attack" },
+				],
+				discardPile: [],
+			};
+			const result = discardHand(deck);
+			expect(result.hand).toHaveLength(0);
+			expect(result.discardPile).toHaveLength(2);
+			expect(result.drawPile).toHaveLength(1);
+		});
+	});
+
+	describe("reshuffleDeck", () => {
+		it("全カードを山札に戻してシャッフルする", () => {
+			const rng = new RNG(SEED);
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [{ id: "card-1", type: "move" }],
+				hand: [{ id: "card-2", type: "attack" }],
+				discardPile: [{ id: "card-3", type: "wait" }],
+			};
+			const result = reshuffleDeck(deck, rng);
+			expect(result.drawPile).toHaveLength(3);
+			expect(result.hand).toHaveLength(0);
+			expect(result.discardPile).toHaveLength(0);
+		});
+	});
+});

--- a/frontend/src/game/deck.ts
+++ b/frontend/src/game/deck.ts
@@ -1,0 +1,130 @@
+/**
+ * デッキシステム
+ * @see docs/spec/mvp/rules.md
+ * @see docs/spec/mvp/cards.md
+ */
+
+import { HAND_LIMIT, INITIAL_DECK } from "../constants";
+import type { Card, CardType, DeckState } from "../types";
+import type { RNG } from "../utils/rng";
+
+let cardIdCounter = 0;
+
+/**
+ * カードIDカウンターをリセット（テスト用）
+ */
+export function resetCardIdCounter(): void {
+	cardIdCounter = 0;
+}
+
+/**
+ * カードを1枚生成
+ */
+function createCard(type: CardType): Card {
+	cardIdCounter++;
+	return { id: `card-${cardIdCounter}`, type };
+}
+
+/**
+ * 指定種別のカードを指定枚数生成
+ */
+function createCards(type: CardType, count: number): Card[] {
+	return Array.from({ length: count }, () => createCard(type));
+}
+
+/**
+ * 初期デッキを生成（シャッフル済み）
+ */
+export function createInitialDeck(rng: RNG): Card[] {
+	const cards: Card[] = [
+		...createCards("move", INITIAL_DECK.moveCards),
+		...createCards("attack", INITIAL_DECK.attackCards),
+		...createCards("wait", INITIAL_DECK.waitCards),
+	];
+	return rng.shuffle(cards);
+}
+
+/**
+ * 初期デッキ状態を生成（山札にシャッフル済みデッキをセット）
+ */
+export function createInitialDeckState(rng: RNG): DeckState {
+	return {
+		drawPile: createInitialDeck(rng),
+		hand: [],
+		discardPile: [],
+	};
+}
+
+/**
+ * 山札からカードを引いて手札に加える
+ * 山札が不足する場合は捨て札をシャッフルして山札に戻す
+ */
+export function drawCards(
+	deck: DeckState,
+	rng: RNG,
+	count?: number,
+): DeckState {
+	const drawCount = count ?? Math.max(0, HAND_LIMIT - deck.hand.length);
+	if (drawCount <= 0) return deck;
+
+	let drawPile = [...deck.drawPile];
+	let discardPile = [...deck.discardPile];
+	const hand = [...deck.hand];
+
+	for (let i = 0; i < drawCount; i++) {
+		if (drawPile.length === 0 && discardPile.length === 0) {
+			break;
+		}
+		if (drawPile.length === 0) {
+			drawPile = rng.shuffle(discardPile);
+			discardPile = [];
+		}
+		const card = drawPile.shift();
+		if (card !== undefined) {
+			hand.push(card);
+		}
+	}
+
+	return { drawPile, hand, discardPile };
+}
+
+/**
+ * 手札からカードを使用（捨て札へ移動）
+ */
+export function playCard(deck: DeckState, cardId: string): DeckState {
+	const cardIndex = deck.hand.findIndex((c) => c.id === cardId);
+	if (cardIndex === -1) {
+		return deck;
+	}
+
+	const hand = [...deck.hand];
+	const [card] = hand.splice(cardIndex, 1);
+	return {
+		drawPile: [...deck.drawPile],
+		hand,
+		discardPile: [...deck.discardPile, card],
+	};
+}
+
+/**
+ * 手札をすべて捨て札に移動
+ */
+export function discardHand(deck: DeckState): DeckState {
+	return {
+		drawPile: [...deck.drawPile],
+		hand: [],
+		discardPile: [...deck.discardPile, ...deck.hand],
+	};
+}
+
+/**
+ * デッキをリセット（全カードを山札に戻してシャッフル）
+ */
+export function reshuffleDeck(deck: DeckState, rng: RNG): DeckState {
+	const allCards = [...deck.drawPile, ...deck.hand, ...deck.discardPile];
+	return {
+		drawPile: rng.shuffle(allCards),
+		hand: [],
+		discardPile: [],
+	};
+}

--- a/frontend/src/game/index.ts
+++ b/frontend/src/game/index.ts
@@ -1,2 +1,3 @@
-export * from "./state";
+export * from "./deck";
 export * from "./map";
+export * from "./state";

--- a/frontend/src/game/map.test.ts
+++ b/frontend/src/game/map.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { MAP_HEIGHT, MAP_WIDTH } from "../constants";
-import { createFixedLayoutMap, generateMapPlacement } from "./map";
 import { RNG } from "../utils/rng";
+import { createFixedLayoutMap, generateMapPlacement } from "./map";
 
 describe("map", () => {
 	describe("createFixedLayoutMap", () => {

--- a/frontend/src/game/map.ts
+++ b/frontend/src/game/map.ts
@@ -5,7 +5,7 @@
 
 import { ENEMY_COUNT, MAP_HEIGHT, MAP_WIDTH, STAIRS_COUNT } from "../constants";
 import type { GameMap, Position, Tile } from "../types";
-import { RNG } from "../utils/rng";
+import type { RNG } from "../utils/rng";
 
 export type MapPlacement = {
 	map: GameMap;

--- a/frontend/src/game/state.test.ts
+++ b/frontend/src/game/state.test.ts
@@ -3,9 +3,9 @@ import {
 	ENEMY_COUNT,
 	ENEMY_HP,
 	INITIAL_FLOOR,
-	MAX_AP,
 	MAP_HEIGHT,
 	MAP_WIDTH,
+	MAX_AP,
 	PLAYER_INITIAL_HP,
 } from "../constants";
 import {

--- a/frontend/src/game/state.ts
+++ b/frontend/src/game/state.ts
@@ -19,8 +19,8 @@ import type {
 	Screen,
 	Turn,
 } from "../types";
-import { generateMapPlacement } from "./map";
 import { RNG } from "../utils/rng";
+import { generateMapPlacement } from "./map";
 
 const cloneRng = (rng: RNG): RNG => rng.clone();
 


### PR DESCRIPTION
## 概要
- カードデータ構造とデッキシステム（山札・手札・捨て札）を実装
- 初期デッキ生成、ドロー、カード使用、手札全破棄、リシャッフルの各操作を提供
- 14件のテストケースで動作を検証

## 対応Issue
Closes #89

## 変更内容
- `game/deck.ts`: デッキ操作関数（`createInitialDeck`, `createInitialDeckState`, `drawCards`, `playCard`, `discardHand`, `reshuffleDeck`）
- `game/deck.test.ts`: デッキシステムのテスト（14件）
- `game/index.ts`: deck モジュールのエクスポート追加

## テスト計画
- [x] 初期デッキが18枚（移動8、攻撃8、待機2）で生成される
- [x] 同じシードで同じ順序のデッキが生成される
- [x] 手札上限まで山札からカードを引ける
- [x] 山札不足時に捨て札をリシャッフルして補充する
- [x] カード使用で手札から捨て札に移動する
- [x] 手札全破棄が正しく動作する
- [x] デッキリセットで全カードが山札に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)