### PR TITLE
feat: 手札UIの実装

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,14 +1,20 @@
 import { Application } from "pixi.js";
 import { COLORS } from "./constants";
-import { createInitialGameState } from "./game";
+import { createInitialDeckState, createInitialGameState, drawCards } from "./game";
 import type { GameState } from "./types";
-import { getMapPixelSize, MapRenderer } from "./ui";
+import { HandRenderer, MapRenderer, getMapPixelSize } from "./ui";
+
+/** 手札エリアの高さ */
+const HAND_AREA_HEIGHT = 160;
 
 /** 現在のゲーム状態 */
 let gameState: GameState;
 
 /** マップレンダラー */
 let mapRenderer: MapRenderer;
+
+/** 手札レンダラー */
+let handRenderer: HandRenderer;
 
 /**
  * ゲーム状態を更新して再描画
@@ -24,8 +30,10 @@ function updateState(newState: GameState): void {
 function renderGame(): void {
 	if (gameState.screen === "game") {
 		mapRenderer.render(gameState.map, gameState.player, gameState.enemies);
+		handRenderer.render(gameState.deck.hand, gameState.player.ap);
 	} else {
 		mapRenderer.clear();
+		handRenderer.clear();
 	}
 }
 
@@ -35,7 +43,7 @@ async function main() {
 
 	await app.init({
 		width: mapSize.width,
-		height: mapSize.height,
+		height: mapSize.height + HAND_AREA_HEIGHT,
 		backgroundColor: COLORS.background,
 	});
 
@@ -45,8 +53,22 @@ async function main() {
 	mapRenderer = new MapRenderer();
 	app.stage.addChild(mapRenderer.getContainer());
 
-	// ゲーム状態を初期化
+	// 手札レンダラーを初期化
+	handRenderer = new HandRenderer();
+	const handContainer = handRenderer.getContainer();
+	handContainer.x = mapSize.width / 2;
+	handContainer.y = mapSize.height + HAND_AREA_HEIGHT / 2 - 60;
+	app.stage.addChild(handContainer);
+
+	handRenderer.setOnCardSelect((card) => {
+		console.log("カード選択:", card.type, card.id);
+	});
+
+	// ゲーム状態を初期化（デッキ生成＋手札ドロー込み）
 	gameState = createInitialGameState();
+	const deck = createInitialDeckState(gameState.rng);
+	const deckWithHand = drawCards(deck, gameState.rng);
+	gameState = { ...gameState, deck: deckWithHand };
 
 	// 初回描画
 	renderGame();

--- a/frontend/src/ui/handRenderer.ts
+++ b/frontend/src/ui/handRenderer.ts
@@ -1,0 +1,163 @@
+/**
+ * 手札UI描画
+ * @see docs/spec/mvp/cards.md
+ */
+
+import { Container, Graphics, Text } from "pixi.js";
+import { CARD_COST } from "../constants";
+import type { Card, CardType } from "../types";
+
+/** カード描画定数 */
+const CARD_WIDTH = 90;
+const CARD_HEIGHT = 120;
+const CARD_GAP = 8;
+const CARD_RADIUS = 8;
+
+/** カード色定義 */
+const CARD_COLORS = {
+	move: { bg: 0x2a5a8c, border: 0x4a8cca },
+	attack: { bg: 0x8c2a2a, border: 0xca4a4a },
+	wait: { bg: 0x5a5a2a, border: 0x8c8c4a },
+	disabled: { bg: 0x2a2a2a, border: 0x4a4a4a },
+	selectedBorder: 0xffd700,
+} as const;
+
+/** カード種別の日本語名 */
+const CARD_TYPE_NAME: Record<CardType, string> = {
+	move: "移動",
+	attack: "攻撃",
+	wait: "待機",
+};
+
+/**
+ * 手札レンダラー
+ */
+export class HandRenderer {
+	private container: Container;
+	private selectedCardId: string | null = null;
+	private onCardSelect: ((card: Card) => void) | null = null;
+
+	constructor() {
+		this.container = new Container();
+	}
+
+	/**
+	 * ルートコンテナを取得
+	 */
+	getContainer(): Container {
+		return this.container;
+	}
+
+	/**
+	 * カード選択コールバックを設定
+	 */
+	setOnCardSelect(callback: (card: Card) => void): void {
+		this.onCardSelect = callback;
+	}
+
+	/**
+	 * 選択中カードIDを設定
+	 */
+	setSelectedCard(cardId: string | null): void {
+		this.selectedCardId = cardId;
+	}
+
+	/**
+	 * 手札を描画
+	 */
+	render(hand: Card[], currentAp: number): void {
+		this.container.removeChildren();
+
+		const totalWidth =
+			hand.length * CARD_WIDTH + (hand.length - 1) * CARD_GAP;
+		const startX = -totalWidth / 2;
+
+		for (let i = 0; i < hand.length; i++) {
+			const card = hand[i];
+			const x = startX + i * (CARD_WIDTH + CARD_GAP);
+			const cost = CARD_COST[card.type];
+			const enabled = currentAp >= cost;
+			const selected = card.id === this.selectedCardId;
+
+			const cardContainer = this.createCardView(card, x, 0, enabled, selected);
+			this.container.addChild(cardContainer);
+		}
+	}
+
+	/**
+	 * カード1枚分のビューを生成
+	 */
+	private createCardView(
+		card: Card,
+		x: number,
+		y: number,
+		enabled: boolean,
+		selected: boolean,
+	): Container {
+		const cardContainer = new Container();
+		cardContainer.x = x;
+		cardContainer.y = y;
+
+		// 背景
+		const bg = new Graphics();
+		const colors = enabled ? CARD_COLORS[card.type] : CARD_COLORS.disabled;
+		const borderColor = selected ? CARD_COLORS.selectedBorder : colors.border;
+		const borderWidth = selected ? 3 : 2;
+
+		bg.roundRect(0, 0, CARD_WIDTH, CARD_HEIGHT, CARD_RADIUS);
+		bg.fill(colors.bg);
+		bg.roundRect(0, 0, CARD_WIDTH, CARD_HEIGHT, CARD_RADIUS);
+		bg.stroke({ color: borderColor, width: borderWidth });
+
+		cardContainer.addChild(bg);
+
+		// カード名
+		const nameText = new Text({
+			text: CARD_TYPE_NAME[card.type],
+			style: {
+				fontSize: 16,
+				fontFamily: "sans-serif",
+				fill: enabled ? 0xffffff : 0x888888,
+				fontWeight: "bold",
+			},
+		});
+		nameText.anchor.set(0.5, 0);
+		nameText.x = CARD_WIDTH / 2;
+		nameText.y = 30;
+		cardContainer.addChild(nameText);
+
+		// APコスト
+		const cost = CARD_COST[card.type];
+		const costText = new Text({
+			text: `AP: ${cost}`,
+			style: {
+				fontSize: 13,
+				fontFamily: "sans-serif",
+				fill: enabled ? 0xcccccc : 0x666666,
+			},
+		});
+		costText.anchor.set(0.5, 0);
+		costText.x = CARD_WIDTH / 2;
+		costText.y = 70;
+		cardContainer.addChild(costText);
+
+		// インタラクション
+		if (enabled) {
+			cardContainer.eventMode = "static";
+			cardContainer.cursor = "pointer";
+			cardContainer.on("pointerdown", () => {
+				this.onCardSelect?.(card);
+			});
+		}
+
+		return cardContainer;
+	}
+
+	/**
+	 * クリア
+	 */
+	clear(): void {
+		this.container.removeChildren();
+		this.selectedCardId = null;
+	}
+}

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from "./coordinates";
+export * from "./handRenderer";
 export * from "./mapRenderer";


### PR DESCRIPTION
## 概要
- PixiJSベースの手札カードUI描画を実装
- カード種別ごとの色分け表示（移動:青、攻撃:赤、待機:黄）
- AP不足時の非活性表示、選択時のハイライト対応

## 対応Issue
Closes #90

## 変更内容
- `ui/handRenderer.ts`: HandRendererクラス（カード描画、選択コールバック、非活性表示）
- `ui/index.ts`: handRendererのエクスポート追加
- `main.ts`: 手札UIの統合（画面拡張、デッキ生成＋手札ドロー、描画連携）

## テスト計画
- [x] ビルド成功
- [x] 既存テスト全パス（63件）
- [x] 画面にカード5枚が表示されることを目視確認
- [ ] AP不足のカードがグレーアウトされることを確認
- [x] カードクリック時にコンソールにログが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)