### PR TITLE
feat: 方向選択UIの実装

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,8 +1,17 @@
 import { Application } from "pixi.js";
 import { COLORS } from "./constants";
-import { createInitialDeckState, createInitialGameState, drawCards } from "./game";
-import type { GameState } from "./types";
-import { HandRenderer, MapRenderer, getMapPixelSize } from "./ui";
+import {
+	createInitialDeckState,
+	createInitialGameState,
+	drawCards,
+} from "./game";
+import type { Card, GameState } from "./types";
+import {
+	DirectionSelector,
+	getMapPixelSize,
+	HandRenderer,
+	MapRenderer,
+} from "./ui";
 
 /** 手札エリアの高さ */
 const HAND_AREA_HEIGHT = 160;
@@ -15,6 +24,12 @@ let mapRenderer: MapRenderer;
 
 /** 手札レンダラー */
 let handRenderer: HandRenderer;
+
+/** 方向選択UI */
+let directionSelector: DirectionSelector;
+
+/** 方向選択待ちのカード */
+let pendingCard: Card | null = null;
 
 /**
  * ゲーム状態を更新して再描画
@@ -60,8 +75,39 @@ async function main() {
 	handContainer.y = mapSize.height + HAND_AREA_HEIGHT / 2 - 60;
 	app.stage.addChild(handContainer);
 
+	// 方向選択UIを初期化
+	directionSelector = new DirectionSelector();
+	const directionContainer = directionSelector.getContainer();
+	directionContainer.x = mapSize.width / 2;
+	directionContainer.y = mapSize.height + HAND_AREA_HEIGHT / 2 - 60;
+	app.stage.addChild(directionContainer);
+
+	directionSelector.setOnDirectionSelect((direction) => {
+		console.log(
+			"カード使用:",
+			pendingCard?.type,
+			pendingCard?.id,
+			"方向:",
+			direction,
+		);
+		// TODO: ゲームロジックにカード使用を反映
+		directionSelector.hide();
+		pendingCard = null;
+	});
+
+	directionSelector.setOnCancel(() => {
+		directionSelector.hide();
+		pendingCard = null;
+	});
+
 	handRenderer.setOnCardSelect((card) => {
-		console.log("カード選択:", card.type, card.id);
+		if (card.type === "wait") {
+			console.log("待機カード使用:", card.id);
+			// TODO: ゲームロジックに待機を反映
+		} else {
+			pendingCard = card;
+			directionSelector.show();
+		}
 	});
 
 	// ゲーム状態を初期化（デッキ生成＋手札ドロー込み）

--- a/frontend/src/ui/directionSelector.ts
+++ b/frontend/src/ui/directionSelector.ts
@@ -1,0 +1,166 @@
+/**
+ * 方向選択UI
+ * 移動・攻撃カード使用時に上下左右の方向を選択する
+ */
+
+import { Container, Graphics, Text } from "pixi.js";
+import type { Direction } from "../types";
+
+/** ボタンサイズ */
+const BUTTON_SIZE = 56;
+const BUTTON_GAP = 8;
+const BUTTON_RADIUS = 8;
+
+/** 方向ボタン色 */
+const DIRECTION_COLORS = {
+	bg: 0x2a5a3a,
+	border: 0x4a8a5a,
+} as const;
+
+/** キャンセルボタン色 */
+const CANCEL_COLORS = {
+	bg: 0x5a3a3a,
+	border: 0x8a5a5a,
+} as const;
+
+/** 方向ボタン定義 */
+const DIRECTION_BUTTONS: {
+	direction: Direction;
+	label: string;
+	dx: number;
+	dy: number;
+}[] = [
+	{ direction: "up", label: "\u2191", dx: 0, dy: -(BUTTON_SIZE + BUTTON_GAP) },
+	{
+		direction: "left",
+		label: "\u2190",
+		dx: -(BUTTON_SIZE + BUTTON_GAP),
+		dy: 0,
+	},
+	{ direction: "right", label: "\u2192", dx: BUTTON_SIZE + BUTTON_GAP, dy: 0 },
+	{ direction: "down", label: "\u2193", dx: 0, dy: BUTTON_SIZE + BUTTON_GAP },
+];
+
+/**
+ * 方向選択UIコンポーネント
+ */
+export class DirectionSelector {
+	private container: Container;
+	private onDirectionSelect: ((direction: Direction) => void) | null = null;
+	private onCancel: (() => void) | null = null;
+
+	constructor() {
+		this.container = new Container();
+		this.container.visible = false;
+	}
+
+	/**
+	 * ルートコンテナを取得
+	 */
+	getContainer(): Container {
+		return this.container;
+	}
+
+	/**
+	 * 方向選択コールバックを設定
+	 */
+	setOnDirectionSelect(callback: (direction: Direction) => void): void {
+		this.onDirectionSelect = callback;
+	}
+
+	/**
+	 * キャンセルコールバックを設定
+	 */
+	setOnCancel(callback: () => void): void {
+		this.onCancel = callback;
+	}
+
+	/**
+	 * 表示
+	 */
+	show(): void {
+		this.container.removeChildren();
+
+		// 方向ボタン
+		for (const btn of DIRECTION_BUTTONS) {
+			const button = this.createButton(
+				btn.label,
+				btn.dx,
+				btn.dy,
+				DIRECTION_COLORS,
+				() => this.onDirectionSelect?.(btn.direction),
+			);
+			this.container.addChild(button);
+		}
+
+		// キャンセルボタン
+		const cancelY = (BUTTON_SIZE + BUTTON_GAP) * 2;
+		const cancelButton = this.createButton(
+			"\u53D6\u6D88",
+			0,
+			cancelY,
+			CANCEL_COLORS,
+			() => this.onCancel?.(),
+		);
+		this.container.addChild(cancelButton);
+
+		this.container.visible = true;
+	}
+
+	/**
+	 * 非表示
+	 */
+	hide(): void {
+		this.container.visible = false;
+		this.container.removeChildren();
+	}
+
+	/**
+	 * 表示中かどうか
+	 */
+	isVisible(): boolean {
+		return this.container.visible;
+	}
+
+	/**
+	 * ボタンを生成
+	 */
+	private createButton(
+		label: string,
+		x: number,
+		y: number,
+		colors: { bg: number; border: number },
+		onClick: () => void,
+	): Container {
+		const button = new Container();
+		button.x = x - BUTTON_SIZE / 2;
+		button.y = y - BUTTON_SIZE / 2;
+
+		const bg = new Graphics();
+		bg.roundRect(0, 0, BUTTON_SIZE, BUTTON_SIZE, BUTTON_RADIUS);
+		bg.fill(colors.bg);
+		bg.roundRect(0, 0, BUTTON_SIZE, BUTTON_SIZE, BUTTON_RADIUS);
+		bg.stroke({ color: colors.border, width: 2 });
+		button.addChild(bg);
+
+		const text = new Text({
+			text: label,
+			style: {
+				fontSize: 20,
+				fontFamily: "sans-serif",
+				fill: 0xffffff,
+				fontWeight: "bold",
+			},
+		});
+		text.anchor.set(0.5);
+		text.x = BUTTON_SIZE / 2;
+		text.y = BUTTON_SIZE / 2;
+		button.addChild(text);
+
+		button.eventMode = "static";
+		button.cursor = "pointer";
+		button.on("pointerdown", onClick);
+
+		return button;
+	}
+}

--- a/frontend/src/ui/handRenderer.ts
+++ b/frontend/src/ui/handRenderer.ts
@@ -68,8 +68,7 @@ export class HandRenderer {
 	render(hand: Card[], currentAp: number): void {
 		this.container.removeChildren();
 
-		const totalWidth =
-			hand.length * CARD_WIDTH + (hand.length - 1) * CARD_GAP;
+		const totalWidth = hand.length * CARD_WIDTH + (hand.length - 1) * CARD_GAP;
 		const startX = -totalWidth / 2;
 
 		for (let i = 0; i < hand.length; i++) {

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -3,5 +3,6 @@
  */
 
 export * from "./coordinates";
+export * from "./directionSelector";
 export * from "./handRenderer";
 export * from "./mapRenderer";


### PR DESCRIPTION
## Summary
- 移動・攻撃カード使用時に上下左右の4方向を選択するUIを `DirectionSelector` クラスとして新規実装
- 手札カード選択時のフロー分岐を追加（待機→即実行、移動/攻撃→方向選択UI表示）
- キャンセルボタンで方向選択を取り消し可能

Closes #91

## Test plan
- [ ] `pnpm build` でビルドが通ること（確認済み）
- [ ] `pnpm lint` でリントエラーがないこと（確認済み）
- [ ] 移動・攻撃カード選択時に方向選択UIが表示されること
- [ ] 方向ボタン押下でコンソールにカード使用ログが出力されること
- [ ] キャンセルボタンで方向選択UIが閉じること
- [ ] 待機カード選択時は方向選択UIが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)