### PR TITLE
feat: プレイヤー移動ロジックの実装

### DIFF
--- a/frontend/src/game/action.test.ts
+++ b/frontend/src/game/action.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { CARD_COST, MAP_HEIGHT, MAP_WIDTH, MAX_AP } from "../constants";
+import type { Enemy, GameMap, GameState, Tile } from "../types";
+import { RNG } from "../utils/rng";
+import { executeMove } from "./action";
+
+/**
+ * テスト用の7x7マップを生成（外周壁・内側床）
+ */
+function createTestMap(): GameMap {
+	const map: GameMap = [];
+	for (let y = 0; y < MAP_HEIGHT; y++) {
+		const row: Tile[] = [];
+		for (let x = 0; x < MAP_WIDTH; x++) {
+			const isBoundary =
+				x === 0 || y === 0 || x === MAP_WIDTH - 1 || y === MAP_HEIGHT - 1;
+			row.push({ type: isBoundary ? "wall" : "floor" });
+		}
+		map.push(row);
+	}
+	return map;
+}
+
+/**
+ * テスト用のGameStateを生成
+ */
+function createTestState(overrides?: Partial<GameState>): GameState {
+	const map = createTestMap();
+	return {
+		screen: "game",
+		turn: "player",
+		floor: 1,
+		map,
+		player: {
+			position: { x: 3, y: 3 },
+			hp: 10,
+			maxHp: 10,
+			ap: MAX_AP,
+			maxAp: MAX_AP,
+		},
+		enemies: [],
+		deck: {
+			drawPile: [],
+			hand: [{ id: "move-1", type: "move" }],
+			discardPile: [],
+		},
+		actionLog: [],
+		rng: new RNG(12345),
+		...overrides,
+	};
+}
+
+describe("executeMove", () => {
+	it("床タイルへの移動成功: 位置更新・AP消費・カード捨て札移動・行動ログ", () => {
+		const state = createTestState();
+		const result = executeMove(state, "move-1", "right");
+
+		// 位置が更新される
+		expect(result.player.position).toEqual({ x: 4, y: 3 });
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.move);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		expect(result.deck.discardPile[0].id).toBe("move-1");
+		// 行動ログに記録
+		expect(result.actionLog.length).toBeGreaterThan(0);
+	});
+
+	it("壁タイルへの移動失敗: 位置変更なし・AP消費・カード捨て札移動・失敗ログ", () => {
+		// プレイヤーを壁の隣に配置（1,1から上は壁）
+		const state = createTestState({
+			player: {
+				position: { x: 1, y: 1 },
+				hp: 10,
+				maxHp: 10,
+				ap: MAX_AP,
+				maxAp: MAX_AP,
+			},
+		});
+		const result = executeMove(state, "move-1", "up");
+
+		// 位置が変更されない
+		expect(result.player.position).toEqual({ x: 1, y: 1 });
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.move);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		// 行動ログに失敗が記録
+		expect(result.actionLog.length).toBeGreaterThan(0);
+	});
+
+	it("敵がいるマスへの移動失敗: 位置変更なし・AP消費", () => {
+		const enemies: Enemy[] = [
+			{ id: "enemy-1", position: { x: 4, y: 3 }, hp: 3, maxHp: 3 },
+		];
+		const state = createTestState({ enemies });
+		const result = executeMove(state, "move-1", "right");
+
+		// 位置が変更されない
+		expect(result.player.position).toEqual({ x: 3, y: 3 });
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.move);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+	});
+
+	it("階段タイルへの移動成功: 位置更新・行動ログに階段到達記録", () => {
+		const map = createTestMap();
+		// (4,3)を階段タイルに設定
+		map[3][4] = { type: "stairs" };
+
+		const state = createTestState({ map });
+		const result = executeMove(state, "move-1", "right");
+
+		// 位置が更新される
+		expect(result.player.position).toEqual({ x: 4, y: 3 });
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.move);
+		// 行動ログに階段到達が記録
+		const hasStairsLog = result.actionLog.some((log) =>
+			log.message.includes("階段"),
+		);
+		expect(hasStairsLog).toBe(true);
+	});
+
+	it("元のGameStateが変更されない（イミュータブル）", () => {
+		const state = createTestState();
+		const originalPosition = { ...state.player.position };
+		const originalAp = state.player.ap;
+
+		executeMove(state, "move-1", "right");
+
+		expect(state.player.position).toEqual(originalPosition);
+		expect(state.player.ap).toBe(originalAp);
+		expect(state.deck.hand).toHaveLength(1);
+	});
+});

--- a/frontend/src/game/action.ts
+++ b/frontend/src/game/action.ts
@@ -1,0 +1,82 @@
+/**
+ * プレイヤー行動処理
+ * @see docs/spec/mvp/rules.md
+ */
+
+import { CARD_COST, MAP_HEIGHT, MAP_WIDTH } from "../constants";
+import type { Direction, GameState } from "../types";
+import { DIRECTION_DELTA } from "../types";
+import { playCard } from "./deck";
+import { addActionLog, setDeck, updatePlayer } from "./state";
+
+/**
+ * 移動可否を判定
+ */
+function canMove(state: GameState, direction: Direction): boolean {
+	const delta = DIRECTION_DELTA[direction];
+	const nx = state.player.position.x + delta.x;
+	const ny = state.player.position.y + delta.y;
+
+	// マップ範囲外
+	if (nx < 0 || ny < 0 || nx >= MAP_WIDTH || ny >= MAP_HEIGHT) {
+		return false;
+	}
+
+	// 壁タイル
+	if (state.map[ny][nx].type === "wall") {
+		return false;
+	}
+
+	// 敵がいるマス
+	if (state.enemies.some((e) => e.position.x === nx && e.position.y === ny)) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * 移動カード使用時のプレイヤー移動処理
+ *
+ * 成功/失敗に関わらずAP消費・カード使用を行う。
+ * 成功時は位置更新、失敗時はログのみ。
+ */
+export function executeMove(
+	state: GameState,
+	cardId: string,
+	direction: Direction,
+): GameState {
+	// AP消費
+	let next = updatePlayer(state, (p) => ({
+		...p,
+		ap: p.ap - CARD_COST.move,
+	}));
+
+	// カードを捨て札へ
+	next = setDeck(next, playCard(next.deck, cardId));
+
+	// 移動判定
+	if (!canMove(state, direction)) {
+		return addActionLog(next, "移動できなかった");
+	}
+
+	// 位置更新
+	const delta = DIRECTION_DELTA[direction];
+	const nx = state.player.position.x + delta.x;
+	const ny = state.player.position.y + delta.y;
+
+	next = updatePlayer(next, (p) => ({
+		...p,
+		position: { x: nx, y: ny },
+	}));
+
+	next = addActionLog(next, "移動した");
+
+	// 階段判定
+	if (state.map[ny][nx].type === "stairs") {
+		// TODO: 階層遷移は #98 スコープ
+		next = addActionLog(next, "階段に到達した");
+	}
+
+	return next;
+}

--- a/frontend/src/game/index.ts
+++ b/frontend/src/game/index.ts
@@ -1,3 +1,4 @@
+export * from "./action";
 export * from "./deck";
 export * from "./map";
 export * from "./state";

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,6 +4,7 @@ import {
 	createInitialDeckState,
 	createInitialGameState,
 	drawCards,
+	executeMove,
 } from "./game";
 import type { Card, GameState } from "./types";
 import {
@@ -83,14 +84,14 @@ async function main() {
 	app.stage.addChild(directionContainer);
 
 	directionSelector.setOnDirectionSelect((direction) => {
-		console.log(
-			"カード使用:",
-			pendingCard?.type,
-			pendingCard?.id,
-			"方向:",
-			direction,
-		);
-		// TODO: ゲームロジックにカード使用を反映
+		if (pendingCard) {
+			if (pendingCard.type === "move") {
+				updateState(executeMove(gameState, pendingCard.id, direction));
+			} else if (pendingCard.type === "attack") {
+				// TODO: 攻撃処理は #93 スコープ
+				console.log("攻撃:", pendingCard.id, "方向:", direction);
+			}
+		}
 		directionSelector.hide();
 		pendingCard = null;
 	});


### PR DESCRIPTION
## 概要

プレイヤーの移動処理ロジックを実装し、方向選択UIと連携させました。

## 変更内容

- `executeMove` 関数の実装（移動カード使用時の処理）
  - 移動可否判定（壁・敵・マップ範囲外チェック）
  - AP消費・カード捨て札移動処理
  - 位置更新・行動ログ記録
  - 階段到達判定
- 移動ロジックのユニットテスト追加
- 方向選択UIからの移動処理呼び出し

## テスト計画

- [x] 床タイルへの移動成功テスト
- [x] 壁タイルへの移動失敗テスト
- [x] 敵がいるマスへの移動失敗テスト
- [x] 階段タイルへの移動成功テスト
- [x] イミュータビリティテスト

Closes #91