### PR TITLE
feat: プレイヤー攻撃処理の実装

### DIFF
--- a/frontend/src/game/action.test.ts
+++ b/frontend/src/game/action.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { CARD_COST, MAP_HEIGHT, MAP_WIDTH, MAX_AP } from "../constants";
+import {
+	CARD_COST,
+	ENEMY_HP,
+	MAP_HEIGHT,
+	MAP_WIDTH,
+	MAX_AP,
+	PLAYER_ATTACK_DAMAGE,
+} from "../constants";
 import type { Enemy, GameMap, GameState, Tile } from "../types";
 import { RNG } from "../utils/rng";
-import { executeMove } from "./action";
+import { executeAttack, executeMove } from "./action";
 
 /**
  * テスト用の7x7マップを生成（外周壁・内側床）
@@ -134,6 +141,162 @@ describe("executeMove", () => {
 		executeMove(state, "move-1", "right");
 
 		expect(state.player.position).toEqual(originalPosition);
+		expect(state.player.ap).toBe(originalAp);
+		expect(state.deck.hand).toHaveLength(1);
+	});
+});
+
+describe("executeAttack", () => {
+	it("攻撃成功: 敵HPが減少・AP消費・カード捨て札移動・行動ログ", () => {
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				position: { x: 4, y: 3 },
+				hp: ENEMY_HP,
+				maxHp: ENEMY_HP,
+			},
+		];
+		const state = createTestState({
+			enemies,
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const result = executeAttack(state, "attack-1", "right");
+
+		// 敵HPが減少
+		expect(result.enemies).toHaveLength(1);
+		expect(result.enemies[0].hp).toBe(ENEMY_HP - PLAYER_ATTACK_DAMAGE);
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.attack);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		expect(result.deck.discardPile[0].id).toBe("attack-1");
+		// 行動ログに記録
+		expect(result.actionLog.length).toBeGreaterThan(0);
+		expect(result.actionLog[0].message).toBe("敵に攻撃した");
+	});
+
+	it("攻撃成功（敵HP0で死亡）: 敵がenemiesから削除される", () => {
+		const enemies: Enemy[] = [
+			{ id: "enemy-1", position: { x: 4, y: 3 }, hp: 1, maxHp: ENEMY_HP },
+		];
+		const state = createTestState({
+			enemies,
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const result = executeAttack(state, "attack-1", "right");
+
+		// 敵が削除される
+		expect(result.enemies).toHaveLength(0);
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.attack);
+		// 行動ログに死亡が記録
+		expect(result.actionLog[0].message).toBe("敵を倒した");
+	});
+
+	it("攻撃不成立（敵がいない方向）: AP消費・カード捨て札移動・失敗ログ", () => {
+		const state = createTestState({
+			enemies: [],
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const result = executeAttack(state, "attack-1", "right");
+
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.attack);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		// 失敗ログ
+		expect(result.actionLog[0].message).toBe("攻撃できなかった");
+	});
+
+	it("攻撃不成立（壁方向）: AP消費・カード捨て札移動", () => {
+		const state = createTestState({
+			player: {
+				position: { x: 1, y: 1 },
+				hp: 10,
+				maxHp: 10,
+				ap: MAX_AP,
+				maxAp: MAX_AP,
+			},
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const result = executeAttack(state, "attack-1", "up");
+
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.attack);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		// 失敗ログ
+		expect(result.actionLog[0].message).toBe("攻撃できなかった");
+	});
+
+	it("攻撃不成立（マップ外方向）: AP消費・カード捨て札移動", () => {
+		const state = createTestState({
+			player: {
+				position: { x: 0, y: 0 },
+				hp: 10,
+				maxHp: 10,
+				ap: MAX_AP,
+				maxAp: MAX_AP,
+			},
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const result = executeAttack(state, "attack-1", "up");
+
+		// AP消費
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.attack);
+		// カードが捨て札に移動
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		// 失敗ログ
+		expect(result.actionLog[0].message).toBe("攻撃できなかった");
+	});
+
+	it("元のGameStateが変更されない（イミュータブル）", () => {
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				position: { x: 4, y: 3 },
+				hp: ENEMY_HP,
+				maxHp: ENEMY_HP,
+			},
+		];
+		const state = createTestState({
+			enemies,
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const originalEnemyHp = state.enemies[0].hp;
+		const originalAp = state.player.ap;
+
+		executeAttack(state, "attack-1", "right");
+
+		expect(state.enemies[0].hp).toBe(originalEnemyHp);
 		expect(state.player.ap).toBe(originalAp);
 		expect(state.deck.hand).toHaveLength(1);
 	});

--- a/frontend/src/game/action.ts
+++ b/frontend/src/game/action.ts
@@ -3,11 +3,22 @@
  * @see docs/spec/mvp/rules.md
  */
 
-import { CARD_COST, MAP_HEIGHT, MAP_WIDTH } from "../constants";
+import {
+	CARD_COST,
+	MAP_HEIGHT,
+	MAP_WIDTH,
+	PLAYER_ATTACK_DAMAGE,
+} from "../constants";
 import type { Direction, GameState } from "../types";
 import { DIRECTION_DELTA } from "../types";
 import { playCard } from "./deck";
-import { addActionLog, setDeck, updatePlayer } from "./state";
+import {
+	addActionLog,
+	removeEnemy,
+	setDeck,
+	updateEnemy,
+	updatePlayer,
+} from "./state";
 
 /**
  * 移動可否を判定
@@ -79,4 +90,83 @@ export function executeMove(
 	}
 
 	return next;
+}
+
+/**
+ * 攻撃成立を判定
+ *
+ * 成立条件:
+ * - 指定方向1マス先がマップ内
+ * - 指定方向1マス先が壁タイルではない
+ * - 指定方向1マス先に敵が存在する
+ */
+function canAttack(
+	state: GameState,
+	direction: Direction,
+): { hit: false } | { hit: true; enemyId: string } {
+	const delta = DIRECTION_DELTA[direction];
+	const nx = state.player.position.x + delta.x;
+	const ny = state.player.position.y + delta.y;
+
+	// マップ範囲外
+	if (nx < 0 || ny < 0 || nx >= MAP_WIDTH || ny >= MAP_HEIGHT) {
+		return { hit: false };
+	}
+
+	// 壁タイル
+	if (state.map[ny][nx].type === "wall") {
+		return { hit: false };
+	}
+
+	// 敵が存在するか
+	const enemy = state.enemies.find(
+		(e) => e.position.x === nx && e.position.y === ny,
+	);
+	if (!enemy) {
+		return { hit: false };
+	}
+
+	return { hit: true, enemyId: enemy.id };
+}
+
+/**
+ * 攻撃カード使用時のプレイヤー攻撃処理
+ *
+ * 成功/失敗に関わらずAP消費・カード使用を行う。
+ * 成功時は敵にダメージ、HP0以下で敵を削除。
+ */
+export function executeAttack(
+	state: GameState,
+	cardId: string,
+	direction: Direction,
+): GameState {
+	// AP消費
+	let next = updatePlayer(state, (p) => ({
+		...p,
+		ap: p.ap - CARD_COST.attack,
+	}));
+
+	// カードを捨て札へ
+	next = setDeck(next, playCard(next.deck, cardId));
+
+	// 攻撃判定
+	const result = canAttack(state, direction);
+	if (!result.hit) {
+		return addActionLog(next, "攻撃できなかった");
+	}
+
+	// 敵にダメージ
+	next = updateEnemy(next, result.enemyId, (e) => ({
+		...e,
+		hp: e.hp - PLAYER_ATTACK_DAMAGE,
+	}));
+
+	// 敵HP0以下で死亡処理
+	const target = next.enemies.find((e) => e.id === result.enemyId);
+	if (target && target.hp <= 0) {
+		next = removeEnemy(next, result.enemyId);
+		return addActionLog(next, "敵を倒した");
+	}
+
+	return addActionLog(next, "敵に攻撃した");
 }


### PR DESCRIPTION
## 概要
- 攻撃カード使用時の攻撃判定関数 `canAttack()` を追加
- 攻撃実行関数 `executeAttack()` を追加
- 攻撃成立条件（マップ内・壁でない・敵が存在）の判定
- 敵へのダメージ処理（`PLAYER_ATTACK_DAMAGE = 1`）
- AP消費処理（成功/失敗に関わらず消費）
- カードの捨て札移動（成功/失敗に関わらず移動）
- 敵HP0以下時の死亡処理（`removeEnemy()`による敵削除）
- 行動ログへの記録（攻撃成功/失敗/敵撃破）

Closes #93

## テスト計画
- [x] 攻撃成功: 敵HPが減少・AP消費・カード捨て札移動・行動ログ
- [x] 攻撃成功（敵HP0で死亡）: 敵がenemiesから削除される
- [x] 攻撃不成立（敵がいない方向）: AP消費・カード捨て札移動・失敗ログ
- [x] 攻撃不成立（壁方向）: AP消費・カード捨て札移動
- [x] 攻撃不成立（マップ外方向）: AP消費・カード捨て札移動
- [x] 元のGameStateが変更されない（イミュータブル）
- [x] リント通過
- [x] 全テスト通過（74件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)