### PR TITLE
feat: 階層遷移処理を実装

### DIFF
--- a/frontend/src/game/action.test.ts
+++ b/frontend/src/game/action.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	CARD_COST,
+	ENEMY_COUNT,
 	ENEMY_HP,
 	MAP_HEIGHT,
 	MAP_WIDTH,
@@ -114,23 +115,35 @@ describe("executeMove", () => {
 		expect(result.deck.discardPile).toHaveLength(1);
 	});
 
-	it("階段タイルへの移動成功: 位置更新・行動ログに階段到達記録", () => {
+	it("階段タイルへの移動成功: 階層遷移が発生する", () => {
 		const map = createTestMap();
 		// (4,3)を階段タイルに設定
+		map[3][4] = { type: "stairs" };
+
+		const state = createTestState({ map, floor: 1 });
+		const result = executeMove(state, "move-1", "right");
+
+		// 階層が +1
+		expect(result.floor).toBe(2);
+		// 新マップが生成される
+		expect(result.map).toHaveLength(MAP_HEIGHT);
+		// 敵が新規配置される
+		expect(result.enemies).toHaveLength(ENEMY_COUNT);
+		// 行動ログに階層遷移が記録
+		const hasFloorLog = result.actionLog.some((log) =>
+			log.message.includes("2階に到達した"),
+		);
+		expect(hasFloorLog).toBe(true);
+	});
+
+	it("階段タイルへの移動成功: 遷移後のターンが player", () => {
+		const map = createTestMap();
 		map[3][4] = { type: "stairs" };
 
 		const state = createTestState({ map });
 		const result = executeMove(state, "move-1", "right");
 
-		// 位置が更新される
-		expect(result.player.position).toEqual({ x: 4, y: 3 });
-		// AP消費
-		expect(result.player.ap).toBe(MAX_AP - CARD_COST.move);
-		// 行動ログに階段到達が記録
-		const hasStairsLog = result.actionLog.some((log) =>
-			log.message.includes("階段"),
-		);
-		expect(hasStairsLog).toBe(true);
+		expect(result.turn).toBe("player");
 	});
 
 	it("元のGameStateが変更されない（イミュータブル）", () => {

--- a/frontend/src/game/action.ts
+++ b/frontend/src/game/action.ts
@@ -13,6 +13,7 @@ import type { Direction, GameState } from "../types";
 import { DIRECTION_DELTA } from "../types";
 import { applyDamageToEnemy } from "./combat";
 import { playCard } from "./deck";
+import { transitionFloor } from "./floor";
 import { addActionLog, setDeck, updatePlayer } from "./state";
 
 /**
@@ -80,8 +81,7 @@ export function executeMove(
 
 	// 階段判定
 	if (state.map[ny][nx].type === "stairs") {
-		// TODO: 階層遷移は #98 スコープ
-		next = addActionLog(next, "階段に到達した");
+		return transitionFloor(next);
 	}
 
 	return next;

--- a/frontend/src/game/floor.test.ts
+++ b/frontend/src/game/floor.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+	ENEMY_COUNT,
+	ENEMY_HP,
+	HAND_LIMIT,
+	MAP_HEIGHT,
+	MAP_WIDTH,
+	MAX_AP,
+	TOTAL_DECK_SIZE,
+} from "../constants";
+import type { GameMap, GameState, Tile } from "../types";
+import { RNG } from "../utils/rng";
+import { createInitialDeckState } from "./deck";
+import { transitionFloor } from "./floor";
+
+/**
+ * テスト用の7x7マップを生成（外周壁・内側床・階段1つ）
+ */
+function createTestMap(): GameMap {
+	const map: GameMap = [];
+	for (let y = 0; y < MAP_HEIGHT; y++) {
+		const row: Tile[] = [];
+		for (let x = 0; x < MAP_WIDTH; x++) {
+			const isBoundary =
+				x === 0 || y === 0 || x === MAP_WIDTH - 1 || y === MAP_HEIGHT - 1;
+			row.push({ type: isBoundary ? "wall" : "floor" });
+		}
+		map.push(row);
+	}
+	return map;
+}
+
+/**
+ * テスト用のGameStateを生成
+ */
+function createTestState(overrides?: Partial<GameState>): GameState {
+	const rng = new RNG(12345);
+	const map = createTestMap();
+	return {
+		screen: "game",
+		turn: "player",
+		floor: 1,
+		map,
+		player: {
+			position: { x: 3, y: 3 },
+			hp: 7,
+			maxHp: 10,
+			ap: 1,
+			maxAp: MAX_AP,
+		},
+		enemies: [{ id: "enemy-1", position: { x: 2, y: 2 }, hp: 3, maxHp: 3 }],
+		deck: createInitialDeckState(rng),
+		actionLog: [],
+		rng,
+		...overrides,
+	};
+}
+
+describe("transitionFloor", () => {
+	it("階層番号が +1 される", () => {
+		const state = createTestState({ floor: 3 });
+		const result = transitionFloor(state);
+
+		expect(result.floor).toBe(4);
+	});
+
+	it("新マップが生成される", () => {
+		const state = createTestState();
+		const result = transitionFloor(state);
+
+		// マップが存在し、正しいサイズ
+		expect(result.map).toHaveLength(MAP_HEIGHT);
+		expect(result.map[0]).toHaveLength(MAP_WIDTH);
+	});
+
+	it("プレイヤーHPが維持される", () => {
+		const state = createTestState({
+			player: {
+				position: { x: 3, y: 3 },
+				hp: 7,
+				maxHp: 10,
+				ap: 1,
+				maxAp: MAX_AP,
+			},
+		});
+		const result = transitionFloor(state);
+
+		expect(result.player.hp).toBe(7);
+		expect(result.player.maxHp).toBe(10);
+	});
+
+	it("敵が新規配置される（ENEMY_COUNT体）", () => {
+		const state = createTestState();
+		const result = transitionFloor(state);
+
+		expect(result.enemies).toHaveLength(ENEMY_COUNT);
+		for (const enemy of result.enemies) {
+			expect(enemy.hp).toBe(ENEMY_HP);
+			expect(enemy.maxHp).toBe(ENEMY_HP);
+		}
+	});
+
+	it("デッキが全カード山札に戻りシャッフルされる", () => {
+		const state = createTestState();
+		const result = transitionFloor(state);
+
+		// 手札と捨て札は空
+		expect(result.deck.hand).toHaveLength(HAND_LIMIT);
+		expect(result.deck.discardPile).toHaveLength(0);
+		// 山札 + 手札 = 全カード数
+		expect(result.deck.drawPile.length + result.deck.hand.length).toBe(
+			TOTAL_DECK_SIZE,
+		);
+	});
+
+	it("ターンが player に設定される", () => {
+		const state = createTestState({ turn: "enemy" });
+		const result = transitionFloor(state);
+
+		expect(result.turn).toBe("player");
+	});
+
+	it("APが最大値にリセットされる", () => {
+		const state = createTestState({
+			player: {
+				position: { x: 3, y: 3 },
+				hp: 7,
+				maxHp: 10,
+				ap: 0,
+				maxAp: MAX_AP,
+			},
+		});
+		const result = transitionFloor(state);
+
+		expect(result.player.ap).toBe(MAX_AP);
+	});
+
+	it("手札が補充される", () => {
+		const state = createTestState();
+		const result = transitionFloor(state);
+
+		expect(result.deck.hand.length).toBeGreaterThan(0);
+		expect(result.deck.hand).toHaveLength(HAND_LIMIT);
+	});
+
+	it("行動ログに記録される", () => {
+		const state = createTestState({ floor: 1 });
+		const result = transitionFloor(state);
+
+		const hasFloorLog = result.actionLog.some((log) =>
+			log.message.includes("2階に到達した"),
+		);
+		expect(hasFloorLog).toBe(true);
+	});
+
+	it("元のGameStateが変更されない（イミュータブル）", () => {
+		const state = createTestState();
+		const originalFloor = state.floor;
+		const originalHp = state.player.hp;
+		const originalPosition = { ...state.player.position };
+
+		transitionFloor(state);
+
+		expect(state.floor).toBe(originalFloor);
+		expect(state.player.hp).toBe(originalHp);
+		expect(state.player.position).toEqual(originalPosition);
+	});
+});

--- a/frontend/src/game/floor.ts
+++ b/frontend/src/game/floor.ts
@@ -1,0 +1,68 @@
+/**
+ * 階層遷移処理
+ * @see docs/spec/mvp/rules.md
+ */
+
+import { ENEMY_HP } from "../constants";
+import type { Enemy, GameState } from "../types";
+import { reshuffleDeck } from "./deck";
+import { generateMapPlacement } from "./map";
+import {
+	addActionLog,
+	setDeck,
+	setEnemies,
+	setFloor,
+	setMap,
+	updatePlayer,
+} from "./state";
+import { startPlayerTurn } from "./turn";
+
+/**
+ * 階層遷移処理
+ *
+ * プレイヤーが階段に到達した時に次の階層へ遷移する。
+ * 1. 階層番号を +1
+ * 2. 新マップを生成
+ * 3. プレイヤー位置を新マップの配置位置に更新（HPはそのまま維持）
+ * 4. 敵を新マップの配置で初期化
+ * 5. デッキをリセット・シャッフル
+ * 6. プレイヤーターン開始処理（AP リセット + 手札補充）
+ * 7. 行動ログに記録
+ */
+export function transitionFloor(state: GameState): GameState {
+	// 1. 階層番号を +1
+	let next = setFloor(state, state.floor + 1);
+
+	// 2. 新マップを生成
+	const { map, player, enemies } = generateMapPlacement(next.rng);
+
+	next = setMap(next, map);
+
+	// 3. プレイヤー位置を新マップの配置位置に更新（HPはそのまま維持）
+	next = updatePlayer(next, (p) => ({
+		...p,
+		position: player,
+	}));
+
+	// 4. 敵を新マップの配置で初期化
+	const enemyStates: Enemy[] = enemies.map((position, index) => ({
+		id: `enemy-${index + 1}`,
+		position,
+		hp: ENEMY_HP,
+		maxHp: ENEMY_HP,
+	}));
+	next = setEnemies(next, enemyStates);
+
+	// 5. デッキをリセット・シャッフル
+	next = setDeck(next, reshuffleDeck(next.deck, next.rng));
+
+	// 6. プレイヤーターン開始処理（AP リセット + 手札補充）
+	next = startPlayerTurn(next);
+
+	// 7. 行動ログに記録
+	next = addActionLog(next, `${next.floor}階に到達した`);
+
+	// TODO: セーブ処理 (#104)
+
+	return next;
+}

--- a/frontend/src/game/index.ts
+++ b/frontend/src/game/index.ts
@@ -1,5 +1,6 @@
 export * from "./action";
 export * from "./deck";
+export * from "./floor";
 export * from "./map";
 export * from "./state";
 export * from "./turn";


### PR DESCRIPTION
## Summary
- 階段タイルに移動した時に次の階層へ遷移する `transitionFloor` 関数を実装
- `executeMove` の階段判定を `transitionFloor` 呼び出しに置き換え
- 階層番号+1、新マップ生成、プレイヤーHP維持、敵の新規配置、デッキリシャッフル、ターン開始処理、行動ログ記録を行う

Closes #98

## Test plan
- [x] 階層番号が +1 される
- [x] 新マップが生成される
- [x] プレイヤーHPが維持される
- [x] 敵がENEMY_COUNT体配置される
- [x] デッキがリセット・シャッフルされる
- [x] ターンが player に設定される
- [x] APが最大値にリセットされる
- [x] 手札が補充される
- [x] 行動ログに記録される
- [x] 階段移動時に階層遷移が発生する
- [x] 遷移後のターンが player
- [x] 全144テスト通過、リントエラー0件、ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)