### PR TITLE
feat: 敵撃破アニメーションを追加

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -309,11 +309,22 @@ async function updateStateWithAttackAnimation(
 	if (isAnimating) return;
 	isAnimating = true;
 
+	const defeated = !newState.enemies.some((e) => e.id === hitEnemyId);
 	applyState(newState);
 
 	try {
-		render();
+		// 撃破時は敵の再描画をスキップ（アニメーション用にGraphicsを保持）
+		render(false, false, defeated);
+
+		// ヒットエフェクト
 		await mapRenderer.animateAttackHit(hitEnemyId, PLAYER_ATTACK_DAMAGE);
+
+		// 撃破演出
+		if (defeated) {
+			await mapRenderer.animateEnemyDefeat(hitEnemyId);
+			// 撃破後、敵描画を反映
+			render();
+		}
 	} finally {
 		isAnimating = false;
 	}

--- a/frontend/src/ui/mapRenderer.test.ts
+++ b/frontend/src/ui/mapRenderer.test.ts
@@ -10,15 +10,32 @@ vi.mock("../utils/tween", () => ({
 	Easing: {
 		easeOut: (t: number) => t,
 		easeOutCubic: (t: number) => t,
+		easeInOut: (t: number) => t,
 	},
 	tween: vi.fn(
 		(
-			target: { alpha?: number; x?: number; y?: number },
-			to: { alpha?: number; x?: number; y?: number },
+			target: {
+				alpha?: number;
+				x?: number;
+				y?: number;
+				scale?: { x: number; y: number };
+				rotation?: number;
+			},
+			to: {
+				alpha?: number;
+				x?: number;
+				y?: number;
+				scaleX?: number;
+				scaleY?: number;
+				rotation?: number;
+			},
 		) => {
 			if (to.alpha !== undefined) target.alpha = to.alpha;
 			if (to.x !== undefined) target.x = to.x;
 			if (to.y !== undefined) target.y = to.y;
+			if (to.scaleX !== undefined && target.scale) target.scale.x = to.scaleX;
+			if (to.scaleY !== undefined && target.scale) target.scale.y = to.scaleY;
+			if (to.rotation !== undefined) target.rotation = to.rotation;
 			return Promise.resolve();
 		},
 	),
@@ -225,5 +242,64 @@ describe("MapRenderer 攻撃エフェクト", () => {
 		// シェイク完了後にコンテナ座標が元に戻ること
 		expect(container.x).toBe(originalX);
 		expect(container.y).toBe(originalY);
+	});
+});
+
+describe("MapRenderer 敵撃破アニメーション", () => {
+	it("animateEnemyDefeatが正常に完了する", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [{ id: "e1", position: { x: 1, y: 1 }, hp: 3, maxHp: 3 }];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		await expect(renderer.animateEnemyDefeat("e1")).resolves.toBeUndefined();
+	});
+
+	it("撃破アニメーション完了後に敵Graphicsが削除される", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [{ id: "e1", position: { x: 1, y: 1 }, hp: 3, maxHp: 3 }];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		// enemiesContainerに敵Graphicsが存在すること
+		const container = renderer.getContainer();
+		const enemiesContainer = container.children[1];
+		expect(enemiesContainer.children.length).toBe(1);
+
+		await renderer.animateEnemyDefeat("e1");
+
+		// 撃破後、敵Graphicsが削除されていること
+		expect(enemiesContainer.children.length).toBe(0);
+	});
+
+	it("存在しない敵IDでanimateEnemyDefeatを呼んでもエラーにならない", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, []);
+
+		await expect(
+			renderer.animateEnemyDefeat("nonexistent"),
+		).resolves.toBeUndefined();
 	});
 });

--- a/frontend/src/ui/mapRenderer.ts
+++ b/frontend/src/ui/mapRenderer.ts
@@ -66,6 +66,12 @@ const DAMAGE_POPUP_RISE = 24;
 /** ダメージポップアップのアニメーション時間（ms） */
 const DAMAGE_POPUP_DURATION = 600;
 
+/** 敵撃破アニメーションの時間（ms） */
+const DEFEAT_DURATION = 400;
+
+/** 敵撃破アニメーションの回転量（180度） */
+const DEFEAT_ROTATION = Math.PI;
+
 /**
  * タイル種別に対応する色を取得
  */
@@ -410,6 +416,33 @@ export class MapRenderer {
 			this.animateScreenShake(),
 			...(enemyGridPos ? [this.animateDamagePopup(enemyGridPos, damage)] : []),
 		]);
+	}
+
+	/**
+	 * 敵撃破アニメーション
+	 * 縮小 + 透明化 + 回転の複合アニメーションで消滅演出
+	 * @param enemyId 撃破された敵のID
+	 */
+	async animateEnemyDefeat(enemyId: string): Promise<void> {
+		const graphics = this.enemyGraphicsMap.get(enemyId);
+		if (!graphics) return;
+
+		// pivotを中心に設定し、座標を補正
+		graphics.pivot.set(CELL_SIZE / 2, CELL_SIZE / 2);
+		graphics.x += CELL_SIZE / 2;
+		graphics.y += CELL_SIZE / 2;
+
+		await tween(
+			graphics,
+			{ scaleX: 0, scaleY: 0, alpha: 0, rotation: DEFEAT_ROTATION },
+			{ duration: DEFEAT_DURATION, easing: Easing.easeInOut },
+		);
+
+		// Graphics削除
+		this.enemiesContainer.removeChild(graphics);
+		graphics.destroy();
+		this.enemyGraphicsMap.delete(enemyId);
+		this.enemyGridPosMap.delete(enemyId);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- 敵撃破時に縮小 + 透明化 + 回転（180度）の複合アニメーション（400ms）で消滅演出を追加
- `mapRenderer.ts` に `animateEnemyDefeat()` メソッドを追加し、pivot中心化 → tweenアニメーション → Graphics手動削除のフローを実装
- `main.ts` の `updateStateWithAttackAnimation` に撃破判定を追加し、撃破時は `skipEnemies=true` でGraphicsを保持してアニメーション後に再描画

## Test plan
- [x] 全208テスト通過（撃破アニメーション3件追加）
- [x] プロダクションビルド成功
- [x] リント/フォーマットエラーなし
- [x] 実際のゲームプレイで敵撃破時に縮小+透明化+回転が表示されることを確認
- [x] HP残存の攻撃では従来通りヒットエフェクトのみ表示されることを確認

closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)