### PR TITLE
feat: カードホバー・選択演出を追加

### DIFF
--- a/frontend/src/ui/handRenderer.test.ts
+++ b/frontend/src/ui/handRenderer.test.ts
@@ -5,6 +5,7 @@
 import type { Container, FederatedPointerEvent } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 import type { Card } from "../types";
+import { tween } from "../utils/tween";
 import {
 	CARD_HEIGHT,
 	CARD_WIDTH,
@@ -182,7 +183,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 	it("無効カード（AP不足）は eventMode が static でない", () => {
 		const renderer = new HandRenderer();
-		// AP=0 で全カード無効
+		// AP=0 なので move / attack は無効（wait は有効のまま）
 		renderer.render(createTestCards(), 0);
 
 		const card0 = findCardContainer(renderer, 0);
@@ -218,5 +219,33 @@ describe("HandRenderer ホバー・選択演出", () => {
 		} as FederatedPointerEvent);
 
 		expect(callback).toHaveBeenCalledWith(cards[2]);
+	});
+
+	it("pointerdown で tween によるパルスアニメーションが実行される", async () => {
+		const renderer = new HandRenderer();
+		const cards = createTestCards();
+		renderer.setOnCardSelect(vi.fn());
+		renderer.render(cards, 10);
+
+		const mockedTween = vi.mocked(tween);
+		mockedTween.mockClear();
+
+		const card2 = findCardContainer(renderer, 2);
+		card2.emit("pointerdown", {
+			global: { x: 0, y: 0 },
+		} as FederatedPointerEvent);
+
+		// fire-and-forget の非同期パルスが完了するまで待機
+		await vi.waitFor(() => {
+			expect(mockedTween).toHaveBeenCalledTimes(2);
+		});
+
+		// 拡大（scaleX/scaleY > 1）と縮小（scaleX/scaleY = 1）の2回呼ばれる
+		expect(mockedTween.mock.calls[0][1]).toEqual(
+			expect.objectContaining({ scaleX: 1.1, scaleY: 1.1 }),
+		);
+		expect(mockedTween.mock.calls[1][1]).toEqual(
+			expect.objectContaining({ scaleX: 1, scaleY: 1 }),
+		);
 	});
 });

--- a/frontend/src/ui/handRenderer.ts
+++ b/frontend/src/ui/handRenderer.ts
@@ -145,7 +145,7 @@ export class HandRenderer {
 			const cost = CARD_COST[card.type];
 			const enabled = currentAp >= cost;
 			const selected = card.id === this.selectedCardId;
-			const hovered = card.id === this.hoveredCardId;
+			const hovered = enabled && card.id === this.hoveredCardId;
 			const y = hovered ? -HOVER_LIFT : 0;
 
 			const cardContainer = this.createCardView(


### PR DESCRIPTION
## Summary
- 手札カードにホバー時の浮き上がり（8px）＋枠色ハイライト（`0x88ccff`）を追加
- クリック時にスケールパルスアニメーション（1.1倍→1倍）を追加
- ホバー・パルスともにAP不足の無効カードには適用されない

## 変更ファイル
- `frontend/src/ui/handRenderer.ts` — ホバー状態管理、枠色切替、パルスアニメーション実装
- `frontend/src/ui/handRenderer.test.ts` — ホバー・選択演出のテスト5件追加

## 設計ポイント
- `render()` は毎回カードを再生成するため、`hoveredCardId` プロパティでホバー状態を保持し再描画時に反映
- パルスアニメーションはfire-and-forget方式で、コールバックは即座に呼ぶ
- `main.ts` の変更は不要（handRenderer内部で完結）

## Test plan
- [x] `pnpm test:run` — 全210テスト通過
- [x] `pnpm build` — ビルド成功
- [x] `pnpm format` / `pnpm lint` — 新規エラーなし

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)