### PR TITLE
fix: テストコードのlint警告を解消

### DIFF
--- a/frontend/src/game/enemyAi.test.ts
+++ b/frontend/src/game/enemyAi.test.ts
@@ -370,10 +370,11 @@ describe("executeEnemyTurn", () => {
 		// 敵2は離れている → 移動
 		const enemy2 = result.enemies.find((e) => e.id === "enemy-2");
 		expect(enemy2).toBeDefined();
+		if (!enemy2) return;
 		// プレイヤー(3,3)に近づいた
 		const originalDist = Math.abs(1 - 3) + Math.abs(1 - 3); // 4
 		const newDist =
-			Math.abs(enemy2!.position.x - 3) + Math.abs(enemy2!.position.y - 3);
+			Math.abs(enemy2.position.x - 3) + Math.abs(enemy2.position.y - 3);
 		expect(newDist).toBeLessThan(originalDist);
 	});
 
@@ -441,7 +442,8 @@ describe("executeEnemyTurn", () => {
 		// 四方が壁で囲まれた敵1(3,5)は移動できずその場に留まる
 		const enemy1 = result.enemies.find((e) => e.id === "enemy-1");
 		expect(enemy1).toBeDefined();
-		expect(enemy1!.position).toEqual({ x: 3, y: 5 });
+		if (!enemy1) return;
+		expect(enemy1.position).toEqual({ x: 3, y: 5 });
 	});
 
 	it("プレイヤーがいるマスへは移動しない（隣接時は攻撃する）", () => {

--- a/frontend/src/game/floor.test.ts
+++ b/frontend/src/game/floor.test.ts
@@ -190,7 +190,7 @@ describe("transitionFloor", () => {
 		expect(storage.saveGame).toHaveBeenCalledWith(result);
 
 		// 念のため、保存された状態が期待通りか確認（例：階層が進んでいるか）
-		const savedState = (storage.saveGame as any).mock.calls[0][0] as GameState;
+		const savedState = vi.mocked(storage.saveGame).mock.calls[0][0];
 		expect(savedState.floor).toBe(6);
 	});
 });


### PR DESCRIPTION
## Summary
- `enemyAi.test.ts`: 非nullアサーション(`!`)をガード句(`if (!var) return`)に置き換え（3箇所）
- `floor.test.ts`: `as any` を `vi.mocked()` に置き換え（1箇所）

## Test plan
- [x] `pnpm lint` で警告0件を確認
- [x] `pnpm test:run` で全214テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)