### PR TITLE
refactor: テストコードの型アサーションをヘルパー関数に改善

### DIFF
--- a/frontend/src/test-utils/pixiTestHelper.test.ts
+++ b/frontend/src/test-utils/pixiTestHelper.test.ts
@@ -1,0 +1,46 @@
+import type { Container } from "pixi.js";
+import { describe, expect, it } from "vitest";
+import { findTextByPrefix, getTexts } from "./pixiTestHelper";
+
+describe("pixiTestHelper", () => {
+	function createMockContainer(children: unknown[]): Container {
+		return { children } as unknown as Container;
+	}
+
+	describe("getTexts", () => {
+		it("textプロパティを持つ子要素のみを返す", () => {
+			const container = createMockContainer([
+				{ text: "HP: 10/10" },
+				{ text: "AP: 3/3" },
+				{ noText: true },
+			]);
+
+			const texts = getTexts(container);
+			expect(texts).toHaveLength(2);
+			expect(texts[0].text).toBe("HP: 10/10");
+			expect(texts[1].text).toBe("AP: 3/3");
+		});
+	});
+
+	describe("findTextByPrefix", () => {
+		it("プレフィックスに一致するテキストを返す", () => {
+			const container = createMockContainer([
+				{ text: "HP: 10/10" },
+				{ text: "AP: 3/3" },
+				{ text: "階層: 1" },
+			]);
+
+			expect(findTextByPrefix(container, "HP:").text).toBe("HP: 10/10");
+			expect(findTextByPrefix(container, "AP:").text).toBe("AP: 3/3");
+			expect(findTextByPrefix(container, "階層:").text).toBe("階層: 1");
+		});
+
+		it("一致するテキストがない場合エラーを投げる", () => {
+			const container = createMockContainer([{ text: "HP: 10/10" }]);
+
+			expect(() => findTextByPrefix(container, "MISSING:")).toThrow(
+				'"MISSING:" で始まるテキスト要素が見つかりません',
+			);
+		});
+	});
+});

--- a/frontend/src/test-utils/pixiTestHelper.ts
+++ b/frontend/src/test-utils/pixiTestHelper.ts
@@ -1,0 +1,26 @@
+import type { Container } from "pixi.js";
+
+/**
+ * Containerの子要素からtextプロパティを持つものだけを抽出する
+ */
+export function getTexts(container: Container): { text: string }[] {
+	return container.children.filter(
+		(child) =>
+			"text" in child && typeof (child as { text: unknown }).text === "string",
+	) as unknown as { text: string }[];
+}
+
+/**
+ * Containerの子要素からプレフィックスに一致するテキスト要素を検索する
+ */
+export function findTextByPrefix(
+	container: Container,
+	prefix: string,
+): { text: string } {
+	const texts = getTexts(container);
+	const found = texts.find((t) => t.text.startsWith(prefix));
+	if (!found) {
+		throw new Error(`"${prefix}" で始まるテキスト要素が見つかりません`);
+	}
+	return found;
+}

--- a/frontend/src/ui/actionLogRenderer.test.ts
+++ b/frontend/src/ui/actionLogRenderer.test.ts
@@ -3,6 +3,16 @@ import { LOG_AREA_WIDTH } from "../constants";
 import type { ActionLogEntry } from "../types";
 import { ActionLogRenderer } from "./actionLogRenderer";
 
+function getLogEntry(
+	container: { children: unknown[] },
+	index: number,
+): { text: string; visible: boolean } {
+	return container.children[2 + index] as unknown as {
+		text: string;
+		visible: boolean;
+	};
+}
+
 describe("ActionLogRenderer", () => {
 	it("getContainerでContainerを返す", () => {
 		const renderer = new ActionLogRenderer(400);
@@ -28,18 +38,9 @@ describe("ActionLogRenderer", () => {
 
 		const container = renderer.getContainer();
 		// children[0] = 背景, children[1] = タイトル, children[2]以降 = ログテキスト
-		const logText1 = container.children[2] as unknown as {
-			text: string;
-			visible: boolean;
-		};
-		const logText2 = container.children[3] as unknown as {
-			text: string;
-			visible: boolean;
-		};
-		const logText3 = container.children[4] as unknown as {
-			text: string;
-			visible: boolean;
-		};
+		const logText1 = getLogEntry(container, 0);
+		const logText2 = getLogEntry(container, 1);
+		const logText3 = getLogEntry(container, 2);
 
 		expect(logText1.text).toBe("プレイヤーが移動した");
 		expect(logText1.visible).toBe(true);
@@ -62,10 +63,7 @@ describe("ActionLogRenderer", () => {
 		const container = renderer.getContainer();
 		// 最初の15件のみ表示される
 		for (let i = 0; i < 15; i++) {
-			const logText = container.children[2 + i] as unknown as {
-				text: string;
-				visible: boolean;
-			};
+			const logText = getLogEntry(container, i);
 			expect(logText.text).toBe(`ログ${i + 1}`);
 			expect(logText.visible).toBe(true);
 		}
@@ -81,10 +79,7 @@ describe("ActionLogRenderer", () => {
 		renderer.clear();
 
 		const container = renderer.getContainer();
-		const logText1 = container.children[2] as unknown as {
-			text: string;
-			visible: boolean;
-		};
+		const logText1 = getLogEntry(container, 0);
 
 		expect(logText1.text).toBe("");
 		expect(logText1.visible).toBe(false);

--- a/frontend/src/ui/statusBar.test.ts
+++ b/frontend/src/ui/statusBar.test.ts
@@ -4,6 +4,7 @@ import {
 	createTweenValueMock,
 	mockEasing,
 } from "../test-utils/mockTween";
+import { findTextByPrefix, getTexts } from "../test-utils/pixiTestHelper";
 import { StatusBar } from "./statusBar";
 
 vi.mock("../utils/tween", () => ({
@@ -33,25 +34,10 @@ describe("StatusBar", () => {
 		statusBar.render(player, 5);
 
 		const container = statusBar.getContainer();
-		const texts = container.children.filter(
-			(child) =>
-				"text" in child &&
-				typeof (child as { text: unknown }).text === "string",
-		);
 
-		const hpText = texts.find((t) =>
-			((t as unknown as { text: string }).text as string).startsWith("HP:"),
-		) as unknown as { text: string };
-		const apText = texts.find((t) =>
-			((t as unknown as { text: string }).text as string).startsWith("AP:"),
-		) as unknown as { text: string };
-		const floorText = texts.find((t) =>
-			((t as unknown as { text: string }).text as string).startsWith("階層:"),
-		) as unknown as { text: string };
-
-		expect(hpText.text).toBe("HP: 7/10");
-		expect(apText.text).toBe("AP: 2/3");
-		expect(floorText.text).toBe("階層: 5");
+		expect(findTextByPrefix(container, "HP:").text).toBe("HP: 7/10");
+		expect(findTextByPrefix(container, "AP:").text).toBe("AP: 2/3");
+		expect(findTextByPrefix(container, "階層:").text).toBe("階層: 5");
 	});
 
 	it("renderでHPバーが正しい比率で描画される", () => {
@@ -95,14 +81,10 @@ describe("StatusBar", () => {
 		statusBar.clear();
 
 		const container = statusBar.getContainer();
-		const texts = container.children.filter(
-			(child) =>
-				"text" in child &&
-				typeof (child as { text: unknown }).text === "string",
-		);
+		const texts = getTexts(container);
 
 		for (const t of texts) {
-			expect((t as unknown as { text: string }).text).toBe("");
+			expect(t.text).toBe("");
 		}
 
 		expect(statusBar.getCurrentHpRatio()).toBe(0);
@@ -166,16 +148,8 @@ describe("StatusBar", () => {
 			await promise;
 
 			const container = statusBar.getContainer();
-			const texts = container.children.filter(
-				(child) =>
-					"text" in child &&
-					typeof (child as { text: unknown }).text === "string",
-			);
-			const hpText = texts.find((t) =>
-				((t as unknown as { text: string }).text as string).startsWith("HP:"),
-			) as unknown as { text: string };
 
-			expect(hpText.text).toBe("HP: 7/10");
+			expect(findTextByPrefix(container, "HP:").text).toBe("HP: 7/10");
 			vi.useRealTimers();
 		});
 
@@ -227,16 +201,8 @@ describe("StatusBar", () => {
 			await statusBar.animateApChange(3, 1, 3);
 
 			const container = statusBar.getContainer();
-			const texts = container.children.filter(
-				(child) =>
-					"text" in child &&
-					typeof (child as { text: unknown }).text === "string",
-			);
-			const apText = texts.find((t) =>
-				((t as unknown as { text: string }).text as string).startsWith("AP:"),
-			) as unknown as { text: string };
 
-			expect(apText.text).toBe("AP: 1/3");
+			expect(findTextByPrefix(container, "AP:").text).toBe("AP: 1/3");
 		});
 
 		it("値が変化しない場合は即座に完了する", async () => {


### PR DESCRIPTION
## 概要
- `as unknown as` パターンを抽出したヘルパー関数（`getTexts`, `findTextByPrefix`）を `test-utils/pixiTestHelper.ts` に追加
- `statusBar.test.ts` の11箇所の型アサーションをヘルパー関数に置換
- `actionLogRenderer.test.ts` の5箇所の型アサーションをファイルローカルの `getLogEntry` ヘルパーに置換
- ヘルパー関数自体のテストを追加

Closes #160

## テスト計画
- [x] `pixiTestHelper.test.ts` の新規テストがパスする
- [x] `statusBar.test.ts` の全テストがパスする（14件）
- [x] `actionLogRenderer.test.ts` の全テストがパスする（6件）
- [x] 全ユニットテストがパスする（261件）
- [x] E2Eテストがパスする
- [x] リント・フォーマットチェックがパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)