### PR TITLE
feat: 敵タイプ別の行動パターンを実装 (#177)

### DIFF
--- a/frontend/src/game/enemyAi.test.ts
+++ b/frontend/src/game/enemyAi.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	ENEMY_ATTACK_DAMAGE,
 	ENEMY_HP,
+	ENEMY_PARAMS,
 	MAX_AP,
 	PLAYER_INITIAL_HP,
 } from "../constants";
@@ -573,5 +574,185 @@ describe("executeEnemyTurn", () => {
 
 		// 同じシードから同じ最初の値が得られる（RNGが進んでいない）
 		expect(rngAfter).toBe(rngBefore);
+	});
+
+	it("totalDamageにnormal敵の攻撃ダメージが含まれる", () => {
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "normal",
+				position: { x: 4, y: 3 },
+				hp: ENEMY_HP,
+				maxHp: ENEMY_HP,
+			},
+		];
+		const state = createTestState({ turn: "enemy", enemies });
+		const { totalDamage } = executeEnemyTurn(state);
+
+		expect(totalDamage).toBe(ENEMY_PARAMS.normal.attackDamage);
+	});
+
+	it("heavy敵が隣接時にattackDamage分のダメージを与える", () => {
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "heavy",
+				position: { x: 4, y: 3 },
+				hp: ENEMY_PARAMS.heavy.hp,
+				maxHp: ENEMY_PARAMS.heavy.hp,
+			},
+		];
+		const state = createTestState({ turn: "enemy", enemies });
+		const { state: result, totalDamage } = executeEnemyTurn(state);
+
+		expect(result.player.hp).toBe(
+			PLAYER_INITIAL_HP - ENEMY_PARAMS.heavy.attackDamage,
+		);
+		expect(totalDamage).toBe(ENEMY_PARAMS.heavy.attackDamage);
+	});
+
+	it("heavy敵は隣接していなくても移動しない", () => {
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "heavy",
+				position: { x: 5, y: 5 },
+				hp: ENEMY_PARAMS.heavy.hp,
+				maxHp: ENEMY_PARAMS.heavy.hp,
+			},
+		];
+		const state = createTestState({ turn: "enemy", enemies });
+		const { state: result, totalDamage } = executeEnemyTurn(state);
+
+		// 移動しない
+		expect(result.enemies[0].position).toEqual({ x: 5, y: 5 });
+		// ダメージなし
+		expect(totalDamage).toBe(0);
+		expect(result.player.hp).toBe(PLAYER_INITIAL_HP);
+	});
+
+	it("scout敵が2マス移動する", () => {
+		// プレイヤー(3,3)、scout(3,5) → 1マス目(3,4)で隣接しないのでもう1マス → (3,4)は隣接なので停止
+		// 再考: scout(3,5) → 1マス目で(3,4)に移動 → 隣接判定で停止
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "scout",
+				position: { x: 5, y: 3 },
+				hp: ENEMY_PARAMS.scout.hp,
+				maxHp: ENEMY_PARAMS.scout.hp,
+			},
+		];
+		// プレイヤー(3,3)、scout(5,3) → 距離2
+		// 1マス目: (4,3)に移動 → 隣接 → 2マス目スキップ
+		const state = createTestState({ turn: "enemy", enemies });
+		const { state: result } = executeEnemyTurn(state);
+
+		// 1マス移動後に隣接 → そこで停止
+		expect(result.enemies[0].position).toEqual({ x: 4, y: 3 });
+	});
+
+	it("scout敵が2マス移動で接近する（隣接しない距離）", () => {
+		// プレイヤー(3,3)、scout(3,1) → 距離2
+		// 1マス目: (3,2)に移動 → 隣接 → 2マス目スキップ
+		// 距離3以上のケースが必要
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "scout",
+				position: { x: 1, y: 1 },
+				hp: ENEMY_PARAMS.scout.hp,
+				maxHp: ENEMY_PARAMS.scout.hp,
+			},
+		];
+		// プレイヤー(3,3)、scout(1,1) → 距離4
+		// 1マス目: 上下左右で(1,2)距離3 vs (2,1)距離3 → 下が優先 → (1,2)
+		// 隣接しない → 2マス目: (1,2)から(1,3)距離2 vs (2,2)距離2 → 下が優先 → (1,3)
+		const state = createTestState({ turn: "enemy", enemies });
+		const { state: result } = executeEnemyTurn(state);
+
+		// 2マス移動
+		expect(result.enemies[0].position).toEqual({ x: 1, y: 3 });
+	});
+
+	it("scout敵の1マス目移動失敗で停止する", () => {
+		// scoutの周囲を壁で囲む
+		const map = createTestMap();
+		map[4][3] = { type: "wall" }; // (3,4)
+		map[5][2] = { type: "wall" }; // (2,5)
+		map[5][4] = { type: "wall" }; // (4,5)
+		// 下(3,6)は外周で既に壁
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "scout",
+				position: { x: 3, y: 5 },
+				hp: ENEMY_PARAMS.scout.hp,
+				maxHp: ENEMY_PARAMS.scout.hp,
+			},
+		];
+		const state = createTestState({
+			turn: "enemy",
+			map,
+			player: {
+				position: { x: 1, y: 1 },
+				hp: PLAYER_INITIAL_HP,
+				maxHp: PLAYER_INITIAL_HP,
+				ap: MAX_AP,
+				maxAp: MAX_AP,
+			},
+			enemies,
+		});
+		const { state: result } = executeEnemyTurn(state);
+
+		// 移動できずその場に留まる
+		expect(result.enemies[0].position).toEqual({ x: 3, y: 5 });
+	});
+
+	it("scout敵が隣接時に攻撃する（移動しない）", () => {
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "scout",
+				position: { x: 4, y: 3 },
+				hp: ENEMY_PARAMS.scout.hp,
+				maxHp: ENEMY_PARAMS.scout.hp,
+			},
+		];
+		const state = createTestState({ turn: "enemy", enemies });
+		const { state: result, totalDamage } = executeEnemyTurn(state);
+
+		expect(result.player.hp).toBe(
+			PLAYER_INITIAL_HP - ENEMY_PARAMS.scout.attackDamage,
+		);
+		expect(totalDamage).toBe(ENEMY_PARAMS.scout.attackDamage);
+		// 移動していない
+		expect(result.enemies[0].position).toEqual({ x: 4, y: 3 });
+	});
+
+	it("異なるタイプの敵が混在した場合のtotalDamageが正しい", () => {
+		// normal(隣接) + heavy(隣接) → totalDamage = 1 + 2 = 3
+		const enemies: Enemy[] = [
+			{
+				id: "enemy-1",
+				type: "normal",
+				position: { x: 4, y: 3 },
+				hp: ENEMY_HP,
+				maxHp: ENEMY_HP,
+			},
+			{
+				id: "enemy-2",
+				type: "heavy",
+				position: { x: 2, y: 3 },
+				hp: ENEMY_PARAMS.heavy.hp,
+				maxHp: ENEMY_PARAMS.heavy.hp,
+			},
+		];
+		const state = createTestState({ turn: "enemy", enemies });
+		const { totalDamage } = executeEnemyTurn(state);
+
+		expect(totalDamage).toBe(
+			ENEMY_PARAMS.normal.attackDamage + ENEMY_PARAMS.heavy.attackDamage,
+		);
 	});
 });

--- a/frontend/src/game/enemyAi.ts
+++ b/frontend/src/game/enemyAi.ts
@@ -3,7 +3,7 @@
  * @see docs/spec/mvp/rules.md
  */
 
-import { ENEMY_ATTACK_DAMAGE, MAP_HEIGHT, MAP_WIDTH } from "../constants";
+import { ENEMY_PARAMS, MAP_HEIGHT, MAP_WIDTH } from "../constants";
 import type { Direction, Enemy, GameState, Position } from "../types";
 import { DIRECTION_DELTA } from "../types";
 import { applyDamageToPlayer, checkGameOver, isDefeated } from "./combat";
@@ -106,10 +106,68 @@ export function pickMoveDirection(
 	return bestDirection;
 }
 
+/**
+ * タイプ別の敵移動処理
+ *
+ * moveDistance=0: 移動しない（heavy）
+ * moveDistance=1: 1マス移動（normal）
+ * moveDistance=2: 2段階移動（scout）
+ *   - 1マス目移動失敗 → 即終了
+ *   - 1マス目移動後に隣接 → 2マス目スキップ
+ *   - 2マス目移動失敗 → 1マス目の位置で停止
+ */
+function moveEnemyByType(
+	state: GameState,
+	enemy: Enemy,
+	moveDistance: number,
+): GameState {
+	if (moveDistance === 0) {
+		return addActionLog(state, "敵は動けなかった");
+	}
+
+	let next = state;
+	for (let step = 0; step < moveDistance; step++) {
+		const currentEnemy = next.enemies.find((e) => e.id === enemy.id);
+		if (!currentEnemy) break;
+
+		// 移動後に隣接している場合、残りの移動をスキップ
+		if (step > 0 && isAdjacent(currentEnemy.position, next.player.position)) {
+			break;
+		}
+
+		const dir = pickMoveDirection(next, currentEnemy);
+		if (dir) {
+			const delta = DIRECTION_DELTA[dir];
+			const newEnemies = next.enemies.map((e) =>
+				e.id === enemy.id
+					? {
+							...e,
+							position: {
+								x: e.position.x + delta.x,
+								y: e.position.y + delta.y,
+							},
+						}
+					: e,
+			);
+			next = setEnemies(next, newEnemies);
+			if (step === 0) {
+				next = addActionLog(next, "敵が移動した");
+			}
+		} else {
+			if (step === 0) {
+				next = addActionLog(next, "敵は動けなかった");
+			}
+			break;
+		}
+	}
+
+	return next;
+}
+
 /** 敵ターン実行結果 */
 export type EnemyTurnResult = {
 	state: GameState;
-	attackCount: number;
+	totalDamage: number;
 };
 
 /**
@@ -126,45 +184,28 @@ export function executeEnemyTurn(state: GameState): EnemyTurnResult {
 	const order = rng.shuffle(state.enemies.map((_e, i) => i));
 
 	let next = { ...state, enemies: state.enemies.map((e) => ({ ...e })), rng };
-	let attackCount = 0;
+	let totalDamage = 0;
 
 	for (const idx of order) {
 		// プレイヤーが死亡していたら残りの敵は行動しない
 		if (isDefeated(next.player.hp)) break;
 
 		const enemy = next.enemies[idx];
+		const params = ENEMY_PARAMS[enemy.type];
 
 		if (isAdjacent(enemy.position, next.player.position)) {
 			// 攻撃
-			next = applyDamageToPlayer(next, ENEMY_ATTACK_DAMAGE);
+			next = applyDamageToPlayer(next, params.attackDamage);
 			next = addActionLog(next, "敵が攻撃した");
-			attackCount++;
+			totalDamage += params.attackDamage;
 		} else {
 			// 移動
-			const dir = pickMoveDirection(next, enemy);
-			if (dir) {
-				const delta = DIRECTION_DELTA[dir];
-				const newEnemies = next.enemies.map((e) =>
-					e.id === enemy.id
-						? {
-								...e,
-								position: {
-									x: e.position.x + delta.x,
-									y: e.position.y + delta.y,
-								},
-							}
-						: e,
-				);
-				next = setEnemies(next, newEnemies);
-				next = addActionLog(next, "敵が移動した");
-			} else {
-				next = addActionLog(next, "敵は動けなかった");
-			}
+			next = moveEnemyByType(next, enemy, params.moveDistance);
 		}
 	}
 
 	// プレイヤー死亡判定
 	next = checkGameOver(next);
 
-	return { state: next, attackCount };
+	return { state: next, totalDamage };
 }

--- a/frontend/src/ui/eventHandlers.ts
+++ b/frontend/src/ui/eventHandlers.ts
@@ -2,7 +2,7 @@
  * イベントハンドラ設定
  */
 
-import { ENEMY_ATTACK_DAMAGE, LOG_AREA_GAP } from "../constants";
+import { LOG_AREA_GAP } from "../constants";
 import {
 	endPlayerTurn,
 	executeAttack,
@@ -289,10 +289,10 @@ export function setupEventHandlers(
 			await ctx.ui.turnBanner.showBanner("enemy");
 
 			const enemiesBefore = next.enemies;
-			const { state: enemyTurnState, attackCount } = executeEnemyTurn(next);
+			const { state: enemyTurnState, totalDamage } = executeEnemyTurn(next);
 			next = enemyTurnState;
 			const enemyMoves = detectEnemyMoves(enemiesBefore, next.enemies);
-			const playerWasAttacked = attackCount > 0;
+			const playerWasAttacked = totalDamage > 0;
 
 			// 敵移動アニメーション
 			if (enemyMoves.length > 0) {
@@ -311,9 +311,7 @@ export function setupEventHandlers(
 				// ゲームオーバー時も攻撃演出中はゲーム画面を維持（暗転後に切り替え）
 				renderGameScreen(ctx);
 				await Promise.all([
-					ctx.ui.mapRenderer.animateEnemyAttackHit(
-						ENEMY_ATTACK_DAMAGE * attackCount,
-					),
+					ctx.ui.mapRenderer.animateEnemyAttackHit(totalDamage),
 					ctx.ui.statusBar.animateHpChange(
 						prevHp,
 						next.player.hp,


### PR DESCRIPTION
## Summary

- `EnemyTurnResult`の`attackCount`を`totalDamage`に変更し、タイプ別ダメージ計算に対応
- `moveEnemyByType`関数を新設し、heavy(静止)・normal(1マス移動)・scout(2マス移動)の移動分岐を実装
- `eventHandlers.ts`を`totalDamage`ベースのダメージ表示に更新

## Test plan

- [x] heavy敵: 隣接攻撃でダメージ2、非隣接で移動しない
- [x] scout敵: 2マス移動、1マス目後隣接で停止、1マス目失敗で停止、隣接攻撃
- [x] totalDamage: 各タイプ単体/混在の合計値検証
- [x] リグレッション: 既存normal敵テスト全件パス（312テスト全パス）
- [x] format/lint/buildクリーン

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)