### PR TITLE
feat: 階層に応じた敵配置ロジックを実装

### DIFF
--- a/frontend/src/constants.test.ts
+++ b/frontend/src/constants.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
 	CARD_COST,
 	ENEMY_ATTACK_DAMAGE,
+	ENEMY_COMPOSITION_TABLE,
 	ENEMY_COUNT,
 	ENEMY_HP,
 	ENEMY_PARAMS,
 	FLOOR_TILE_COUNT,
+	getEnemyComposition,
 	INITIAL_DECK,
 	MAP_HEIGHT,
 	MAP_WIDTH,
@@ -76,6 +78,44 @@ describe("constants", () => {
 		it("旧定数がENEMY_PARAMS.normalと一致する", () => {
 			expect(ENEMY_HP).toBe(ENEMY_PARAMS.normal.hp);
 			expect(ENEMY_ATTACK_DAMAGE).toBe(ENEMY_PARAMS.normal.attackDamage);
+		});
+	});
+
+	describe("getEnemyComposition", () => {
+		it("階層1-2: normal×3", () => {
+			expect(getEnemyComposition(1)).toEqual({ normal: 3, heavy: 0, scout: 0 });
+			expect(getEnemyComposition(2)).toEqual({ normal: 3, heavy: 0, scout: 0 });
+		});
+
+		it("階層3-4: normal×2 + scout×1", () => {
+			expect(getEnemyComposition(3)).toEqual({ normal: 2, heavy: 0, scout: 1 });
+			expect(getEnemyComposition(4)).toEqual({ normal: 2, heavy: 0, scout: 1 });
+		});
+
+		it("階層5-6: normal×2 + heavy×1", () => {
+			expect(getEnemyComposition(5)).toEqual({ normal: 2, heavy: 1, scout: 0 });
+			expect(getEnemyComposition(6)).toEqual({ normal: 2, heavy: 1, scout: 0 });
+		});
+
+		it("階層7-8: normal×1 + heavy×1 + scout×1", () => {
+			expect(getEnemyComposition(7)).toEqual({ normal: 1, heavy: 1, scout: 1 });
+			expect(getEnemyComposition(8)).toEqual({ normal: 1, heavy: 1, scout: 1 });
+		});
+
+		it("階層9+: heavy×1 + scout×2", () => {
+			expect(getEnemyComposition(9)).toEqual({ normal: 0, heavy: 1, scout: 2 });
+			expect(getEnemyComposition(10)).toEqual({
+				normal: 0,
+				heavy: 1,
+				scout: 2,
+			});
+		});
+
+		it("全エントリの合計がENEMY_COUNTと一致", () => {
+			for (const entry of ENEMY_COMPOSITION_TABLE) {
+				const { normal, heavy, scout } = entry.composition;
+				expect(normal + heavy + scout).toBe(ENEMY_COUNT);
+			}
 		});
 	});
 });

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -61,6 +61,30 @@ export const MAP_HEIGHT = 7;
 export const STAIRS_COUNT = 1;
 export const ENEMY_COUNT = 3;
 
+// 階層別敵構成
+export type EnemyComposition = {
+	normal: number;
+	heavy: number;
+	scout: number;
+};
+
+export const ENEMY_COMPOSITION_TABLE: {
+	maxFloor: number;
+	composition: EnemyComposition;
+}[] = [
+	{ maxFloor: 2, composition: { normal: 3, heavy: 0, scout: 0 } },
+	{ maxFloor: 4, composition: { normal: 2, heavy: 0, scout: 1 } },
+	{ maxFloor: 6, composition: { normal: 2, heavy: 1, scout: 0 } },
+	{ maxFloor: 8, composition: { normal: 1, heavy: 1, scout: 1 } },
+	{ maxFloor: Infinity, composition: { normal: 0, heavy: 1, scout: 2 } },
+];
+
+export function getEnemyComposition(floor: number): EnemyComposition {
+	const entry = ENEMY_COMPOSITION_TABLE.find((e) => floor <= e.maxFloor);
+	// 最後のエントリがInfinityなので必ずマッチする
+	return (entry as (typeof ENEMY_COMPOSITION_TABLE)[number]).composition;
+}
+
 // 行動ログ
 export const ACTION_LOG_LIMIT = 50;
 

--- a/frontend/src/game/floor.test.ts
+++ b/frontend/src/game/floor.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	ENEMY_COUNT,
 	ENEMY_HP,
+	ENEMY_PARAMS,
 	HAND_LIMIT,
 	MAP_HEIGHT,
 	MAP_WIDTH,
@@ -186,6 +187,32 @@ describe("transitionFloor", () => {
 		expect(state.floor).toBe(originalFloor);
 		expect(state.player.hp).toBe(originalHp);
 		expect(state.player.position).toEqual(originalPosition);
+	});
+
+	it("階層5遷移時にheavy敵が含まれる", () => {
+		const state = createTestState({ floor: 4 });
+		const result = transitionFloor(state);
+
+		expect(result.floor).toBe(5);
+		expect(result.enemies).toHaveLength(ENEMY_COUNT);
+		const heavyEnemies = result.enemies.filter((e) => e.type === "heavy");
+		expect(heavyEnemies).toHaveLength(1);
+		expect(heavyEnemies[0].hp).toBe(ENEMY_PARAMS.heavy.hp);
+		expect(heavyEnemies[0].maxHp).toBe(ENEMY_PARAMS.heavy.hp);
+	});
+
+	it("階層9遷移時にscout×2 + heavy×1の構成になる", () => {
+		const state = createTestState({ floor: 8 });
+		const result = transitionFloor(state);
+
+		expect(result.floor).toBe(9);
+		expect(result.enemies).toHaveLength(ENEMY_COUNT);
+		const scoutEnemies = result.enemies.filter((e) => e.type === "scout");
+		const heavyEnemies = result.enemies.filter((e) => e.type === "heavy");
+		const normalEnemies = result.enemies.filter((e) => e.type === "normal");
+		expect(scoutEnemies).toHaveLength(2);
+		expect(heavyEnemies).toHaveLength(1);
+		expect(normalEnemies).toHaveLength(0);
 	});
 
 	it("saveGame が呼び出され、更新後の状態が保存される", () => {

--- a/frontend/src/game/floor.ts
+++ b/frontend/src/game/floor.ts
@@ -9,7 +9,7 @@ import { reshuffleDeck } from "./deck";
 import { generateMapPlacement } from "./map";
 import {
 	addActionLog,
-	createEnemiesFromPositions,
+	createEnemiesForFloor,
 	setDeck,
 	setEnemies,
 	setFloor,
@@ -45,8 +45,8 @@ export function transitionFloor(state: GameState): GameState {
 		position: player,
 	}));
 
-	// 4. 敵を新マップの配置で初期化
-	next = setEnemies(next, createEnemiesFromPositions(enemies));
+	// 4. 敵を新マップの配置で初期化（階層に応じたタイプ構成）
+	next = setEnemies(next, createEnemiesForFloor(enemies, next.floor));
 
 	// 5. デッキをリセット・シャッフル
 	next = setDeck(next, reshuffleDeck(next.deck, next.rng));

--- a/frontend/src/game/state.test.ts
+++ b/frontend/src/game/state.test.ts
@@ -14,6 +14,7 @@ import {
 	addActionLog,
 	changeScreen,
 	changeTurn,
+	createEnemiesForFloor,
 	createEnemiesFromPositions,
 	createInitialGameState,
 	createInitialPlayer,
@@ -60,6 +61,46 @@ describe("state", () => {
 			expect(enemies[0].type).toBe("scout");
 			expect(enemies[0].hp).toBe(ENEMY_PARAMS.scout.hp);
 			expect(enemies[0].maxHp).toBe(ENEMY_PARAMS.scout.hp);
+		});
+	});
+
+	describe("createEnemiesForFloor", () => {
+		const positions = [
+			{ x: 1, y: 1 },
+			{ x: 2, y: 2 },
+			{ x: 3, y: 3 },
+		];
+
+		it("階層1: normal×3", () => {
+			const enemies = createEnemiesForFloor(positions, 1);
+			expect(enemies).toHaveLength(3);
+			expect(enemies.every((e) => e.type === "normal")).toBe(true);
+			expect(enemies.every((e) => e.hp === ENEMY_PARAMS.normal.hp)).toBe(true);
+		});
+
+		it("階層3: normal×2 + scout×1", () => {
+			const enemies = createEnemiesForFloor(positions, 3);
+			expect(enemies[0].type).toBe("normal");
+			expect(enemies[1].type).toBe("normal");
+			expect(enemies[2].type).toBe("scout");
+			expect(enemies[2].hp).toBe(ENEMY_PARAMS.scout.hp);
+		});
+
+		it("階層5: normal×2 + heavy×1", () => {
+			const enemies = createEnemiesForFloor(positions, 5);
+			expect(enemies[0].type).toBe("normal");
+			expect(enemies[1].type).toBe("normal");
+			expect(enemies[2].type).toBe("heavy");
+			expect(enemies[2].hp).toBe(ENEMY_PARAMS.heavy.hp);
+		});
+
+		it("各敵にIDと座標が設定される", () => {
+			const enemies = createEnemiesForFloor(positions, 5);
+			expect(enemies[0].id).toBe("enemy-1");
+			expect(enemies[1].id).toBe("enemy-2");
+			expect(enemies[2].id).toBe("enemy-3");
+			expect(enemies[0].position).toEqual({ x: 1, y: 1 });
+			expect(enemies[2].position).toEqual({ x: 3, y: 3 });
 		});
 	});
 

--- a/frontend/src/game/state.ts
+++ b/frontend/src/game/state.ts
@@ -5,6 +5,7 @@
 
 import {
 	ENEMY_PARAMS,
+	getEnemyComposition,
 	INITIAL_FLOOR,
 	MAX_AP,
 	PLAYER_INITIAL_HP,
@@ -42,6 +43,26 @@ export function createEnemiesFromPositions(
 		hp,
 		maxHp: hp,
 	}));
+}
+
+/**
+ * 階層に応じた敵リストを生成
+ */
+export function createEnemiesForFloor(
+	positions: Position[],
+	floor: number,
+): Enemy[] {
+	const composition = getEnemyComposition(floor);
+	const types: EnemyType[] = [
+		...Array<EnemyType>(composition.normal).fill("normal"),
+		...Array<EnemyType>(composition.heavy).fill("heavy"),
+		...Array<EnemyType>(composition.scout).fill("scout"),
+	];
+	return positions.map((position, index) => {
+		const type = types[index] ?? "normal";
+		const { hp } = ENEMY_PARAMS[type];
+		return { id: `enemy-${index + 1}`, type, position, hp, maxHp: hp };
+	});
 }
 
 /**
@@ -106,7 +127,7 @@ export function createInitialGameState(seed?: number): GameState {
 		floor: INITIAL_FLOOR,
 		map,
 		player: { ...initialPlayer, position: player },
-		enemies: createEnemiesFromPositions(enemies),
+		enemies: createEnemiesForFloor(enemies, INITIAL_FLOOR),
 		deck: createEmptyDeckState(),
 		actionLog: [],
 		rng,


### PR DESCRIPTION
## 概要
- `ENEMY_COMPOSITION_TABLE` と `getEnemyComposition()` を追加し、階層番号に応じた敵タイプ構成を返す仕組みを実装
- `createEnemiesForFloor(positions, floor)` を新設し、階層に応じたタイプ別の敵を生成
- `createInitialGameState` と `transitionFloor` の敵生成を `createEnemiesForFloor` に差し替え
- 階層別敵構成テーブル: 1-2階(normal×3)、3-4階(normal×2+scout×1)、5-6階(normal×2+heavy×1)、7-8階(normal×1+heavy×1+scout×1)、9階+(heavy×1+scout×2)
- 全階層帯の構成テスト、合計数の整合性テスト、階層遷移時の構成テストを追加（12テスト追加）

Closes #178

## テスト計画
- [x] `getEnemyComposition` が各階層帯で正しい構成を返すこと
- [x] 全エントリの敵合計が `ENEMY_COUNT` と一致すること
- [x] `createEnemiesForFloor` が階層に応じたタイプと HP を持つ敵を生成すること
- [x] `transitionFloor` で階層5遷移時に heavy 敵が含まれること
- [x] `transitionFloor` で階層9遷移時に scout×2 + heavy×1 の構成になること
- [x] 既存テスト全324件が通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)