### PR TITLE
feat: 敵タイプ別のビジュアル描画を実装

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -109,5 +109,10 @@ export const COLORS = {
 	stairs: 0x4a6a4a,
 	// キャラクター
 	player: 0x4a8cca,
+	// 敵タイプ別カラー
+	enemyNormal: 0xca4a4a,
+	enemyHeavy: 0x8855aa,
+	enemyScout: 0x88cc44,
+	// 後方互換（通常敵カラー）
 	enemy: 0xca4a4a,
 } as const;

--- a/frontend/src/ui/mapRenderer.test.ts
+++ b/frontend/src/ui/mapRenderer.test.ts
@@ -239,6 +239,178 @@ describe("MapRenderer 攻撃エフェクト", () => {
 	});
 });
 
+describe("MapRenderer タイプ別敵描画", () => {
+	it("Normal敵が描画できる", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [
+			{
+				id: "e-normal",
+				position: { x: 1, y: 1 },
+				hp: 3,
+				maxHp: 3,
+				type: "normal" as const,
+			},
+		];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		const container = renderer.getContainer();
+		const enemiesContainer = container.children[1];
+		expect(enemiesContainer.children.length).toBe(1);
+	});
+
+	it("Heavy敵が描画できる", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [
+			{
+				id: "e-heavy",
+				position: { x: 2, y: 2 },
+				hp: 5,
+				maxHp: 5,
+				type: "heavy" as const,
+			},
+		];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		const container = renderer.getContainer();
+		const enemiesContainer = container.children[1];
+		expect(enemiesContainer.children.length).toBe(1);
+	});
+
+	it("Scout敵が描画できる", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [
+			{
+				id: "e-scout",
+				position: { x: 3, y: 3 },
+				hp: 2,
+				maxHp: 2,
+				type: "scout" as const,
+			},
+		];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		const container = renderer.getContainer();
+		const enemiesContainer = container.children[1];
+		expect(enemiesContainer.children.length).toBe(1);
+	});
+
+	it("全タイプの敵が同時に描画できる", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [
+			{
+				id: "e-normal",
+				position: { x: 1, y: 1 },
+				hp: 3,
+				maxHp: 3,
+				type: "normal" as const,
+			},
+			{
+				id: "e-heavy",
+				position: { x: 2, y: 2 },
+				hp: 5,
+				maxHp: 5,
+				type: "heavy" as const,
+			},
+			{
+				id: "e-scout",
+				position: { x: 3, y: 3 },
+				hp: 2,
+				maxHp: 2,
+				type: "scout" as const,
+			},
+		];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		const container = renderer.getContainer();
+		const enemiesContainer = container.children[1];
+		expect(enemiesContainer.children.length).toBe(3);
+	});
+
+	it("Heavy敵の撃破アニメーションが正常に完了する", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [
+			{
+				id: "e-heavy",
+				position: { x: 1, y: 1 },
+				hp: 5,
+				maxHp: 5,
+				type: "heavy" as const,
+			},
+		];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		await expect(
+			renderer.animateEnemyDefeat("e-heavy"),
+		).resolves.toBeUndefined();
+	});
+
+	it("Scout敵の攻撃ヒットアニメーションが正常に完了する", async () => {
+		const renderer = new MapRenderer();
+		const map = createTestMap();
+		const enemies = [
+			{
+				id: "e-scout",
+				position: { x: 1, y: 0 },
+				hp: 2,
+				maxHp: 2,
+				type: "scout" as const,
+			},
+		];
+		const player = {
+			position: { x: 0, y: 0 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.render(map, player, enemies);
+
+		await expect(
+			renderer.animateAttackHit("e-scout", 1),
+		).resolves.toBeUndefined();
+	});
+});
+
 describe("MapRenderer 敵撃破アニメーション", () => {
 	it("animateEnemyDefeatが正常に完了する", async () => {
 		const renderer = new MapRenderer();

--- a/frontend/src/ui/mapRenderer.ts
+++ b/frontend/src/ui/mapRenderer.ts
@@ -14,6 +14,7 @@ import type {
 	TileType,
 } from "../types";
 import { DIRECTION_DELTA } from "../types";
+import type { EnemyType } from "../types/character";
 import { Easing, tween } from "../utils/tween";
 import { gridToPixel } from "./coordinates";
 import type { EnemyMove } from "./enemyMoveDetector";
@@ -71,6 +72,13 @@ const DEFEAT_DURATION = 400;
 
 /** 敵撃破アニメーションの回転量（180度） */
 const DEFEAT_ROTATION = Math.PI;
+
+/** 敵タイプ別パディング（セルサイズからの余白） */
+const ENEMY_PADDING = {
+	normal: 12, // 標準サイズ
+	heavy: 8, // 大きめ（パディング小）
+	scout: 16, // 小さめ（パディング大）
+} as const;
 
 /**
  * タイル種別に対応する色を取得
@@ -246,16 +254,34 @@ export class MapRenderer {
 	}
 
 	/**
-	 * 敵のGraphicsを作成（ローカル座標ベース）
+	 * 敵タイプに応じた色を取得
 	 */
-	private createEnemyGraphics(): Graphics {
+	private getEnemyColor(type: EnemyType): number {
+		switch (type) {
+			case "normal":
+				return COLORS.enemyNormal;
+			case "heavy":
+				return COLORS.enemyHeavy;
+			case "scout":
+				return COLORS.enemyScout;
+			default:
+				return COLORS.enemyNormal;
+		}
+	}
+
+	/**
+	 * 敵のGraphicsを作成（ローカル座標ベース）
+	 * @param type 敵タイプ
+	 */
+	private createEnemyGraphics(type: EnemyType): Graphics {
 		const graphics = new Graphics();
-		const padding = 12;
+		const padding = ENEMY_PADDING[type];
 		const size = CELL_SIZE - padding * 2;
+		const color = this.getEnemyColor(type);
 
 		// ローカル座標でセル内に四角を描画
 		graphics.rect(padding, padding, size, size);
-		graphics.fill(COLORS.enemy);
+		graphics.fill(color);
 
 		return graphics;
 	}
@@ -280,7 +306,7 @@ export class MapRenderer {
 		for (const enemy of enemies) {
 			let graphics = this.enemyGraphicsMap.get(enemy.id);
 			if (!graphics) {
-				graphics = this.createEnemyGraphics();
+				graphics = this.createEnemyGraphics(enemy.type);
 				this.enemyGraphicsMap.set(enemy.id, graphics);
 				this.enemiesContainer.addChild(graphics);
 			}


### PR DESCRIPTION
## 概要

敵タイプ（Normal/Heavy/Scout）ごとに異なる色・形状で描画し、プレイヤーが一目で識別できるようにする。

### 変更内容

- **constants.ts**: 敵タイプ別カラー定数を追加
  - `enemyNormal`: 赤 (0xca4a4a) - 標準サイズ
  - `enemyHeavy`: 紫 (0x8855aa) - 大きめ（高耐久・高火力を視覚的に表現）
  - `enemyScout`: 黄緑 (0x88cc44) - 小さめ（軽量・高機動を視覚的に表現）
  - 後方互換のため `enemy` は維持

- **mapRenderer.ts**: タイプ別描画ロジックを追加
  - `ENEMY_PADDING` 定数でタイプ別のサイズを定義
  - `getEnemyColor()` メソッドでタイプ別の色を取得
  - `createEnemyGraphics()` がタイプに応じた色・サイズで描画

- **mapRenderer.test.ts**: タイプ別描画のテストを追加
  - 各タイプ（Normal/Heavy/Scout）の描画テスト
  - 全タイプ同時描画テスト
  - タイプ別アニメーションテスト

Closes #179

## テスト計画

- [x] `pnpm test:run` - 全330テスト通過
- [x] `pnpm lint` - リントチェック通過
- [ ] `pnpm dev` - 階層3以降でScout/Heavyが異なる見た目で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)