### PR TITLE
refactor: 角丸矩形描画を共通ヘルパーに抽出

### DIFF
--- a/frontend/src/ui/deckViewer.ts
+++ b/frontend/src/ui/deckViewer.ts
@@ -13,6 +13,7 @@ import {
 	CARD_TYPE_SYMBOL,
 	RARITY_COLORS,
 } from "./cardConstants";
+import { drawRoundedRect } from "./graphicsHelpers";
 import { BUTTON_HEIGHT, DECK_BUTTON_WIDTH } from "./layout";
 
 /** カード行の高さ・間隔 */
@@ -203,10 +204,10 @@ export class DeckViewer {
 
 		// 背景
 		const bg = new Graphics();
-		bg.roundRect(0, 0, width, CARD_ROW_HEIGHT, 6);
-		bg.fill(colors.bg);
-		bg.roundRect(0, 0, width, CARD_ROW_HEIGHT, 6);
-		bg.stroke({ color: colors.border, width: 1 });
+		drawRoundedRect(bg, width, CARD_ROW_HEIGHT, 6, colors.bg, {
+			color: colors.border,
+			width: 1,
+		});
 		row.addChild(bg);
 
 		// レアリティバー
@@ -259,22 +260,14 @@ export class DeckViewer {
 		button.y = y;
 
 		const bg = new Graphics();
-		bg.roundRect(
-			0,
-			0,
+		drawRoundedRect(
+			bg,
 			CLOSE_BUTTON_WIDTH,
 			CLOSE_BUTTON_HEIGHT,
 			CLOSE_BUTTON_RADIUS,
+			0x555555,
+			{ color: 0x777777, width: 1 },
 		);
-		bg.fill(0x555555);
-		bg.roundRect(
-			0,
-			0,
-			CLOSE_BUTTON_WIDTH,
-			CLOSE_BUTTON_HEIGHT,
-			CLOSE_BUTTON_RADIUS,
-		);
-		bg.stroke({ color: 0x777777, width: 1 });
 		button.addChild(bg);
 
 		const text = new Text({
@@ -307,10 +300,14 @@ export class DeckViewer {
 		const button = new Container();
 
 		const bg = new Graphics();
-		bg.roundRect(0, 0, DECK_BUTTON_WIDTH, BUTTON_HEIGHT, DECK_BUTTON_RADIUS);
-		bg.fill(DECK_BUTTON_COLORS.bg);
-		bg.roundRect(0, 0, DECK_BUTTON_WIDTH, BUTTON_HEIGHT, DECK_BUTTON_RADIUS);
-		bg.stroke({ color: DECK_BUTTON_COLORS.border, width: 2 });
+		drawRoundedRect(
+			bg,
+			DECK_BUTTON_WIDTH,
+			BUTTON_HEIGHT,
+			DECK_BUTTON_RADIUS,
+			DECK_BUTTON_COLORS.bg,
+			{ color: DECK_BUTTON_COLORS.border, width: 2 },
+		);
 		button.addChild(bg);
 
 		const text = new Text({

--- a/frontend/src/ui/directionSelector.ts
+++ b/frontend/src/ui/directionSelector.ts
@@ -5,6 +5,7 @@
 
 import { Container, Graphics, Text } from "pixi.js";
 import type { Direction } from "../types";
+import { drawRoundedRect } from "./graphicsHelpers";
 
 /** ボタンサイズ */
 const BUTTON_SIZE = 56;
@@ -137,10 +138,10 @@ export class DirectionSelector {
 		button.y = y - BUTTON_SIZE / 2;
 
 		const bg = new Graphics();
-		bg.roundRect(0, 0, BUTTON_SIZE, BUTTON_SIZE, BUTTON_RADIUS);
-		bg.fill(colors.bg);
-		bg.roundRect(0, 0, BUTTON_SIZE, BUTTON_SIZE, BUTTON_RADIUS);
-		bg.stroke({ color: colors.border, width: 2 });
+		drawRoundedRect(bg, BUTTON_SIZE, BUTTON_SIZE, BUTTON_RADIUS, colors.bg, {
+			color: colors.border,
+			width: 2,
+		});
 		button.addChild(bg);
 
 		const text = new Text({

--- a/frontend/src/ui/gameOverScreen.ts
+++ b/frontend/src/ui/gameOverScreen.ts
@@ -3,6 +3,7 @@
  */
 
 import { Container, Graphics, Text } from "pixi.js";
+import { drawRoundedRect } from "./graphicsHelpers";
 
 /** ボタン描画定数 */
 const BUTTON_WIDTH = 240;
@@ -95,10 +96,14 @@ export class GameOverScreen {
 
 		// 背景
 		const bg = new Graphics();
-		bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		bg.fill(BUTTON_COLORS.bg);
-		bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		bg.stroke({ color: BUTTON_COLORS.border, width: 2 });
+		drawRoundedRect(
+			bg,
+			BUTTON_WIDTH,
+			BUTTON_HEIGHT,
+			BUTTON_RADIUS,
+			BUTTON_COLORS.bg,
+			{ color: BUTTON_COLORS.border, width: 2 },
+		);
 		button.addChild(bg);
 
 		// ラベル

--- a/frontend/src/ui/graphicsHelpers.test.ts
+++ b/frontend/src/ui/graphicsHelpers.test.ts
@@ -1,0 +1,57 @@
+import type { Graphics } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { drawRoundedRect } from "./graphicsHelpers";
+
+function createMockGraphics() {
+	const calls: { method: string; args: unknown[] }[] = [];
+	return {
+		_calls: calls,
+		roundRect: vi.fn((...args: unknown[]) => {
+			calls.push({ method: "roundRect", args });
+		}),
+		fill: vi.fn((...args: unknown[]) => {
+			calls.push({ method: "fill", args });
+		}),
+		stroke: vi.fn((...args: unknown[]) => {
+			calls.push({ method: "stroke", args });
+		}),
+	} as unknown as Graphics & { _calls: { method: string; args: unknown[] }[] };
+}
+
+describe("drawRoundedRect", () => {
+	it("roundRect→fill→roundRect→strokeの順に呼び出される", () => {
+		const g = createMockGraphics();
+
+		drawRoundedRect(g, 100, 50, 8, 0x334455, { color: 0xaabbcc, width: 2 });
+
+		expect(g._calls).toEqual([
+			{ method: "roundRect", args: [0, 0, 100, 50, 8] },
+			{ method: "fill", args: [0x334455] },
+			{ method: "roundRect", args: [0, 0, 100, 50, 8] },
+			{ method: "stroke", args: [{ color: 0xaabbcc, width: 2 }] },
+		]);
+	});
+
+	it("オブジェクト形式のfillColorに対応する", () => {
+		const g = createMockGraphics();
+
+		drawRoundedRect(
+			g,
+			200,
+			100,
+			6,
+			{ color: 0x112233, alpha: 0.5 },
+			{
+				color: 0x445566,
+				width: 1,
+			},
+		);
+
+		expect(g._calls).toEqual([
+			{ method: "roundRect", args: [0, 0, 200, 100, 6] },
+			{ method: "fill", args: [{ color: 0x112233, alpha: 0.5 }] },
+			{ method: "roundRect", args: [0, 0, 200, 100, 6] },
+			{ method: "stroke", args: [{ color: 0x445566, width: 1 }] },
+		]);
+	});
+});

--- a/frontend/src/ui/graphicsHelpers.ts
+++ b/frontend/src/ui/graphicsHelpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Graphics描画の共通ヘルパー関数
+ */
+
+import type { FillInput, Graphics } from "pixi.js";
+
+/**
+ * 角丸矩形を塗りつぶし＋ストロークで描画する
+ * 位置は親Containerで制御する前提で、原点(0,0)固定
+ */
+export function drawRoundedRect(
+	graphics: Graphics,
+	width: number,
+	height: number,
+	radius: number,
+	fillColor: FillInput,
+	stroke: { color: number; width: number },
+): void {
+	graphics.roundRect(0, 0, width, height, radius);
+	graphics.fill(fillColor);
+	graphics.roundRect(0, 0, width, height, radius);
+	graphics.stroke(stroke);
+}

--- a/frontend/src/ui/handRenderer.ts
+++ b/frontend/src/ui/handRenderer.ts
@@ -13,6 +13,7 @@ import {
 	CARD_TYPE_NAME,
 	CARD_TYPE_SYMBOL,
 } from "./cardConstants";
+import { drawRoundedRect } from "./graphicsHelpers";
 
 /** カード描画定数 */
 export const CARD_WIDTH = 90;
@@ -268,10 +269,10 @@ export class HandRenderer {
 				: colors.border;
 		const borderWidth = selected ? 3 : 2;
 
-		bg.roundRect(0, 0, CARD_WIDTH, CARD_HEIGHT, CARD_RADIUS);
-		bg.fill(colors.bg);
-		bg.roundRect(0, 0, CARD_WIDTH, CARD_HEIGHT, CARD_RADIUS);
-		bg.stroke({ color: borderColor, width: borderWidth });
+		drawRoundedRect(bg, CARD_WIDTH, CARD_HEIGHT, CARD_RADIUS, colors.bg, {
+			color: borderColor,
+			width: borderWidth,
+		});
 
 		cardContainer.addChild(bg);
 

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -9,6 +9,7 @@ export * from "./deckViewer";
 export * from "./directionSelector";
 export * from "./floorBanner";
 export * from "./gameOverScreen";
+export * from "./graphicsHelpers";
 export * from "./handRenderer";
 export * from "./mapRenderer";
 export * from "./rewardScreen";

--- a/frontend/src/ui/rewardScreen.ts
+++ b/frontend/src/ui/rewardScreen.ts
@@ -13,6 +13,7 @@ import {
 	CARD_TYPE_SYMBOL,
 	RARITY_COLORS,
 } from "./cardConstants";
+import { drawRoundedRect } from "./graphicsHelpers";
 
 /** カードサイズ */
 const REWARD_CARD_WIDTH = 120;
@@ -242,22 +243,14 @@ export class RewardScreen {
 
 		// 背景
 		const bg = new Graphics();
-		bg.roundRect(
-			0,
-			0,
+		drawRoundedRect(
+			bg,
 			REWARD_CARD_WIDTH,
 			REWARD_CARD_HEIGHT,
 			REWARD_CARD_RADIUS,
+			colors.bg,
+			{ color: colors.border, width: 2 },
 		);
-		bg.fill(colors.bg);
-		bg.roundRect(
-			0,
-			0,
-			REWARD_CARD_WIDTH,
-			REWARD_CARD_HEIGHT,
-			REWARD_CARD_RADIUS,
-		);
-		bg.stroke({ color: colors.border, width: 2 });
 		cardContainer.addChild(bg);
 
 		// レアリティバー
@@ -378,10 +371,14 @@ export class RewardScreen {
 
 		// 背景
 		const bg = new Graphics();
-		bg.roundRect(0, 0, width, REMOVE_CARD_HEIGHT, 4);
-		bg.fill(CARD_COLORS[card.type].bg);
-		bg.roundRect(0, 0, width, REMOVE_CARD_HEIGHT, 4);
-		bg.stroke({ color: CARD_COLORS[card.type].border, width: 1 });
+		drawRoundedRect(
+			bg,
+			width,
+			REMOVE_CARD_HEIGHT,
+			4,
+			CARD_COLORS[card.type].bg,
+			{ color: CARD_COLORS[card.type].border, width: 1 },
+		);
 		item.addChild(bg);
 
 		// カード名
@@ -406,10 +403,10 @@ export class RewardScreen {
 		removeBtn.y = (REMOVE_CARD_HEIGHT - removeBtnHeight) / 2;
 
 		const removeBg = new Graphics();
-		removeBg.roundRect(0, 0, removeBtnWidth, removeBtnHeight, 4);
-		removeBg.fill(0x882222);
-		removeBg.roundRect(0, 0, removeBtnWidth, removeBtnHeight, 4);
-		removeBg.stroke({ color: 0xaa4444, width: 1 });
+		drawRoundedRect(removeBg, removeBtnWidth, removeBtnHeight, 4, 0x882222, {
+			color: 0xaa4444,
+			width: 1,
+		});
 		removeBtn.addChild(removeBg);
 
 		const removeBtnText = new Text({
@@ -453,10 +450,10 @@ export class RewardScreen {
 		button.y = y;
 
 		const bg = new Graphics();
-		bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		bg.fill(bgColor);
-		bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		bg.stroke({ color: borderColor, width: 1 });
+		drawRoundedRect(bg, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS, bgColor, {
+			color: borderColor,
+			width: 1,
+		});
 		button.addChild(bg);
 
 		const text = new Text({

--- a/frontend/src/ui/titleScreen.ts
+++ b/frontend/src/ui/titleScreen.ts
@@ -3,6 +3,7 @@
  */
 
 import { Container, Graphics, Text } from "pixi.js";
+import { drawRoundedRect } from "./graphicsHelpers";
 
 /** ボタン描画定数 */
 const BUTTON_WIDTH = 240;
@@ -109,10 +110,10 @@ export class TitleScreen {
 		// 背景
 		const bg = new Graphics();
 		const colors = enabled ? BUTTON_COLORS.active : BUTTON_COLORS.disabled;
-		bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		bg.fill(colors.bg);
-		bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		bg.stroke({ color: colors.border, width: 2 });
+		drawRoundedRect(bg, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS, colors.bg, {
+			color: colors.border,
+			width: 2,
+		});
 		button.addChild(bg);
 
 		// ラベル

--- a/frontend/src/ui/turnEndButton.ts
+++ b/frontend/src/ui/turnEndButton.ts
@@ -5,6 +5,7 @@
 
 import { Container, Graphics, Text } from "pixi.js";
 import type { Turn } from "../types";
+import { drawRoundedRect } from "./graphicsHelpers";
 import { BUTTON_HEIGHT, TURN_END_BUTTON_WIDTH as BUTTON_WIDTH } from "./layout";
 
 /** ボタンサイズ */
@@ -62,10 +63,14 @@ export class TurnEndButton {
 		const colors = enabled ? BUTTON_COLORS.active : BUTTON_COLORS.disabled;
 
 		this.background.clear();
-		this.background.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		this.background.fill(colors.bg);
-		this.background.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, BUTTON_RADIUS);
-		this.background.stroke({ color: colors.border, width: 2 });
+		drawRoundedRect(
+			this.background,
+			BUTTON_WIDTH,
+			BUTTON_HEIGHT,
+			BUTTON_RADIUS,
+			colors.bg,
+			{ color: colors.border, width: 2 },
+		);
 
 		this.label.style.fill = colors.text;
 


### PR DESCRIPTION
## Summary
- `roundRect → fill → roundRect → stroke` の描画パターンを `drawRoundedRect` ヘルパー関数に抽出
- 7ファイル・12箇所の重複コードを1行の関数呼び出しに置換
- ヘルパー関数のユニットテストを追加

Closes #196

## Test plan
- [x] `pnpm lint` — 通過
- [x] `pnpm test:run` — 全401テスト通過
- [x] `pnpm test:e2e` — 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)