### PR TITLE
refactor: オーバーレイ生成を共通ヘルパーに抽出

### DIFF
--- a/frontend/src/ui/deckViewer.ts
+++ b/frontend/src/ui/deckViewer.ts
@@ -13,7 +13,11 @@ import {
 	CARD_TYPE_SYMBOL,
 	RARITY_COLORS,
 } from "./cardConstants";
-import { drawRoundedRect, makeInteractive } from "./graphicsHelpers";
+import {
+	createOverlay,
+	drawRoundedRect,
+	makeInteractive,
+} from "./graphicsHelpers";
 import { BUTTON_HEIGHT, DECK_BUTTON_WIDTH } from "./layout";
 
 /** カード行の高さ・間隔 */
@@ -130,9 +134,7 @@ export class DeckViewer {
 
 		// 半透明オーバーレイ（背面UIへのポインタ入力を吸収）
 		const overlay = new Graphics();
-		overlay.rect(0, 0, screenWidth, screenHeight);
-		overlay.fill({ color: 0x000000, alpha: 0.7 });
-		overlay.eventMode = "static";
+		createOverlay(overlay, screenWidth, screenHeight);
 		this.container.addChild(overlay);
 
 		// タイトル

--- a/frontend/src/ui/graphicsHelpers.test.ts
+++ b/frontend/src/ui/graphicsHelpers.test.ts
@@ -1,11 +1,19 @@
 import type { Container, FederatedPointerEvent, Graphics } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
-import { drawRoundedRect, makeInteractive } from "./graphicsHelpers";
+import {
+	createOverlay,
+	drawRoundedRect,
+	makeInteractive,
+} from "./graphicsHelpers";
 
 function createMockGraphics() {
 	const calls: { method: string; args: unknown[] }[] = [];
 	return {
 		_calls: calls,
+		eventMode: "passive" as string,
+		rect: vi.fn((...args: unknown[]) => {
+			calls.push({ method: "rect", args });
+		}),
 		roundRect: vi.fn((...args: unknown[]) => {
 			calls.push({ method: "roundRect", args });
 		}),
@@ -15,7 +23,11 @@ function createMockGraphics() {
 		stroke: vi.fn((...args: unknown[]) => {
 			calls.push({ method: "stroke", args });
 		}),
-	} as unknown as Graphics & { _calls: { method: string; args: unknown[] }[] };
+	} as unknown as Graphics & {
+		_calls: { method: string; args: unknown[] }[];
+		eventMode: string;
+		rect: ReturnType<typeof vi.fn>;
+	};
 }
 
 describe("drawRoundedRect", () => {
@@ -53,6 +65,32 @@ describe("drawRoundedRect", () => {
 			{ method: "roundRect", args: [0, 0, 200, 100, 6] },
 			{ method: "stroke", args: [{ color: 0x445566, width: 1 }] },
 		]);
+	});
+});
+
+describe("createOverlay", () => {
+	it("指定サイズの矩形を描画する", () => {
+		const g = createMockGraphics();
+
+		createOverlay(g, 800, 600);
+
+		expect(g.rect).toHaveBeenCalledWith(0, 0, 800, 600);
+	});
+
+	it("半透明の黒で塗りつぶす", () => {
+		const g = createMockGraphics();
+
+		createOverlay(g, 800, 600);
+
+		expect(g.fill).toHaveBeenCalledWith({ color: 0x000000, alpha: 0.7 });
+	});
+
+	it("eventModeをstaticに設定する", () => {
+		const g = createMockGraphics();
+
+		createOverlay(g, 800, 600);
+
+		expect(g.eventMode).toBe("static");
 	});
 });
 

--- a/frontend/src/ui/graphicsHelpers.ts
+++ b/frontend/src/ui/graphicsHelpers.ts
@@ -28,6 +28,20 @@ export function drawRoundedRect(
 }
 
 /**
+ * 半透明オーバーレイを設定する（背面UIへのポインタ入力を吸収）
+ * 呼び出し側で new Graphics() を渡す
+ */
+export function createOverlay(
+	graphics: Graphics,
+	screenWidth: number,
+	screenHeight: number,
+): void {
+	graphics.rect(0, 0, screenWidth, screenHeight);
+	graphics.fill({ color: 0x000000, alpha: 0.7 });
+	graphics.eventMode = "static";
+}
+
+/**
  * ボタンのインタラクション設定（eventMode / cursor / pointerdownリスナー）を一括で行う
  */
 export function makeInteractive(

--- a/frontend/src/ui/rewardScreen.ts
+++ b/frontend/src/ui/rewardScreen.ts
@@ -13,7 +13,11 @@ import {
 	CARD_TYPE_SYMBOL,
 	RARITY_COLORS,
 } from "./cardConstants";
-import { drawRoundedRect, makeInteractive } from "./graphicsHelpers";
+import {
+	createOverlay,
+	drawRoundedRect,
+	makeInteractive,
+} from "./graphicsHelpers";
 
 /** カードサイズ */
 const REWARD_CARD_WIDTH = 120;
@@ -76,9 +80,7 @@ export class RewardScreen {
 
 		// 半透明オーバーレイ（背面UIへのポインタ入力を吸収）
 		const overlay = new Graphics();
-		overlay.rect(0, 0, screenWidth, screenHeight);
-		overlay.fill({ color: 0x000000, alpha: 0.7 });
-		overlay.eventMode = "static";
+		createOverlay(overlay, screenWidth, screenHeight);
 		this.container.addChild(overlay);
 
 		// タイトル
@@ -123,9 +125,7 @@ export class RewardScreen {
 
 		// 半透明オーバーレイ（背面UIへのポインタ入力を吸収）
 		const overlay = new Graphics();
-		overlay.rect(0, 0, screenWidth, screenHeight);
-		overlay.fill({ color: 0x000000, alpha: 0.7 });
-		overlay.eventMode = "static";
+		createOverlay(overlay, screenWidth, screenHeight);
 		this.container.addChild(overlay);
 
 		// タイトル


### PR DESCRIPTION
## 概要
- `createOverlay` ヘルパー関数を `graphicsHelpers.ts` に追加
- `rewardScreen.ts` の2箇所（render / renderRemoveSelection）の重複コードを置き換え
- `deckViewer.ts` の1箇所（render）の重複コードを置き換え
- `createOverlay` のユニットテストを追加（3テスト）

Closes #198

## テスト計画
- [x] `createOverlay` のユニットテスト（矩形描画・塗りつぶし・eventMode設定）
- [x] 既存ユニットテスト全通過（408テスト）
- [x] E2Eテスト通過
- [x] Biomeフォーマット・リントチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)