### PR TITLE
refactor: デッキ全カード取得ロジックの共通化

### DIFF
--- a/frontend/src/game/deck.test.ts
+++ b/frontend/src/game/deck.test.ts
@@ -6,6 +6,8 @@ import {
 	createInitialDeckState,
 	discardHand,
 	drawCards,
+	getAllCards,
+	getTotalDeckSize,
 	playCard,
 	resetCardIdCounter,
 	reshuffleDeck,
@@ -183,6 +185,54 @@ describe("deck", () => {
 			expect(result.drawPile).toHaveLength(3);
 			expect(result.hand).toHaveLength(0);
 			expect(result.discardPile).toHaveLength(0);
+		});
+	});
+
+	describe("getAllCards", () => {
+		it("3ゾーンの全カードを結合した配列を返す", () => {
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [{ id: "card-1", type: "move" }],
+				hand: [{ id: "card-2", type: "attack" }],
+				discardPile: [{ id: "card-3", type: "wait" }],
+			};
+			const result = getAllCards(deck);
+			expect(result).toHaveLength(3);
+			expect(result.map((c) => c.id)).toEqual(["card-1", "card-2", "card-3"]);
+		});
+
+		it("空デッキで空配列を返す", () => {
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [],
+				hand: [],
+				discardPile: [],
+			};
+			expect(getAllCards(deck)).toHaveLength(0);
+		});
+	});
+
+	describe("getTotalDeckSize", () => {
+		it("3ゾーンの合計枚数を返す", () => {
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [
+					{ id: "card-1", type: "move" },
+					{ id: "card-2", type: "attack" },
+				],
+				hand: [{ id: "card-3", type: "rush" }],
+				discardPile: [
+					{ id: "card-4", type: "wait" },
+					{ id: "card-5", type: "move" },
+				],
+			};
+			expect(getTotalDeckSize(deck)).toBe(5);
+		});
+
+		it("空デッキで0を返す", () => {
+			const deck: ReturnType<typeof createInitialDeckState> = {
+				drawPile: [],
+				hand: [],
+				discardPile: [],
+			};
+			expect(getTotalDeckSize(deck)).toBe(0);
 		});
 	});
 });

--- a/frontend/src/game/deck.ts
+++ b/frontend/src/game/deck.ts
@@ -8,6 +8,20 @@ import { HAND_LIMIT, INITIAL_DECK } from "../constants";
 import type { Card, CardType, DeckState } from "../types";
 import type { RNG } from "../utils/rng";
 
+/**
+ * デッキの3ゾーン（山札・手札・捨て札）を結合した全カード配列を取得
+ */
+export function getAllCards(deck: DeckState): Card[] {
+	return [...deck.drawPile, ...deck.hand, ...deck.discardPile];
+}
+
+/**
+ * デッキの総枚数を取得（山札＋手札＋捨て札）
+ */
+export function getTotalDeckSize(deck: DeckState): number {
+	return deck.drawPile.length + deck.hand.length + deck.discardPile.length;
+}
+
 let cardIdCounter = 0;
 
 /**
@@ -21,7 +35,7 @@ export function resetCardIdCounter(): void {
  * デッキ内のカードIDからカウンターを初期化（セーブデータ復元用）
  */
 export function initCardIdCounterFromDeck(deck: DeckState): void {
-	const allCards = [...deck.drawPile, ...deck.hand, ...deck.discardPile];
+	const allCards = getAllCards(deck);
 	let maxId = 0;
 	for (const card of allCards) {
 		const match = card.id.match(/^card-(\d+)$/);
@@ -138,7 +152,7 @@ export function discardHand(deck: DeckState): DeckState {
  * デッキをリセット（全カードを山札に戻してシャッフル）
  */
 export function reshuffleDeck(deck: DeckState, rng: RNG): DeckState {
-	const allCards = [...deck.drawPile, ...deck.hand, ...deck.discardPile];
+	const allCards = getAllCards(deck);
 	return {
 		drawPile: rng.shuffle(allCards),
 		hand: [],

--- a/frontend/src/game/reward.ts
+++ b/frontend/src/game/reward.ts
@@ -8,16 +8,11 @@ import {
 	DECK_MIN_SIZE,
 	getEnemyCount,
 } from "../constants";
-import type { CardType, DeckState, GameState, RewardState } from "../types";
+import type { CardType, GameState, RewardState } from "../types";
 import { generateRewardChoices } from "./cardPool";
-import { createCard } from "./deck";
+import { createCard, getTotalDeckSize } from "./deck";
 
-/**
- * デッキの総枚数を取得（山札＋手札＋捨て札）
- */
-export function getTotalDeckSize(deck: DeckState): number {
-	return deck.drawPile.length + deck.hand.length + deck.discardPile.length;
-}
+export { getTotalDeckSize };
 
 /**
  * 報酬状態を生成する

--- a/frontend/src/ui/deckViewer.ts
+++ b/frontend/src/ui/deckViewer.ts
@@ -5,6 +5,7 @@
 
 import { Container, Graphics, Text } from "pixi.js";
 import { CARD_COST, CARD_RARITY } from "../constants";
+import { getAllCards, getTotalDeckSize } from "../game/deck";
 import type { CardType, DeckState } from "../types";
 import {
 	CARD_COLORS,
@@ -129,8 +130,7 @@ export class DeckViewer {
 		this.container.removeChildren();
 
 		const cardCounts = this.countCardsByType(deck);
-		const totalCards =
-			deck.drawPile.length + deck.hand.length + deck.discardPile.length;
+		const totalCards = getTotalDeckSize(deck);
 
 		// 半透明オーバーレイ（背面UIへのポインタ入力を吸収）
 		const overlay = new Graphics();
@@ -179,7 +179,7 @@ export class DeckViewer {
 	 */
 	private countCardsByType(deck: DeckState): Map<CardType, number> {
 		const counts = new Map<CardType, number>();
-		const allCards = [...deck.drawPile, ...deck.hand, ...deck.discardPile];
+		const allCards = getAllCards(deck);
 		for (const card of allCards) {
 			counts.set(card.type, (counts.get(card.type) ?? 0) + 1);
 		}


### PR DESCRIPTION
## 概要
- `getAllCards(deck)`: 3ゾーン（山札・手札・捨て札）を結合した全カード配列を返す共通関数を `deck.ts` に追加
- `getTotalDeckSize(deck)`: デッキの総枚数を返す共通関数を `deck.ts` に追加（`reward.ts` から移動）
- 5箇所の重複ロジックを共通関数で置き換え
  - `deck.ts:initCardIdCounterFromDeck` — `getAllCards` 使用
  - `deck.ts:reshuffleDeck` — `getAllCards` 使用
  - `reward.ts:getTotalDeckSize` — `deck.ts` から再export
  - `deckViewer.ts:render` — `getTotalDeckSize` 使用
  - `deckViewer.ts:countCardsByType` — `getAllCards` 使用

Closes #219

## テスト計画
- [x] `getAllCards` のユニットテスト（3ゾーン結合・空デッキ）
- [x] `getTotalDeckSize` のユニットテスト（合計枚数・空デッキ）
- [x] 既存テスト488件全パス
- [x] E2Eテスト全パス
- [x] Biome lint/format パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)