### PR TITLE
refactor: executeAttack/executeStrongAttackの共通化

### DIFF
--- a/frontend/src/game/action.ts
+++ b/frontend/src/game/action.ts
@@ -198,6 +198,10 @@ function executeAttackBase(
 
 /**
  * 攻撃カード使用時のプレイヤー攻撃処理
+ *
+ * 成功/失敗に関わらずAP消費・カード使用を行う。
+ * 成功時は敵にダメージを与え、HP0以下で敵を削除。
+ * 戻り値の hit でヒット情報を返す。
  */
 export function executeAttack(
 	state: GameState,
@@ -216,6 +220,10 @@ export function executeAttack(
 
 /**
  * 強攻撃カード使用時のプレイヤー攻撃処理
+ *
+ * 成功/失敗に関わらずAP消費・カード使用を行う。
+ * 成功時は敵に大ダメージを与え、HP0以下で敵を削除。
+ * 戻り値の hit でヒット情報を返す。
  */
 export function executeStrongAttack(
 	state: GameState,


### PR DESCRIPTION
## 概要
- 攻撃実行の共通処理を `executeAttackBase` 関数に集約
- `executeAttack` と `executeStrongAttack` が共通関数を利用するよう変更
- 差分（APコスト、ダメージ量、ログメッセージ）のみをパラメータ化

Closes #222

## テスト計画
- [x] 既存の攻撃関連テストが全て通ること（492テスト全通過）
- [x] E2Eテストが通ること
- [x] Biome lint/formatが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)