### PR TITLE
refactor: makeInteractiveヘルパーの利用漏れ修正

### DIFF
--- a/frontend/src/ui/handRenderer.ts
+++ b/frontend/src/ui/handRenderer.ts
@@ -13,7 +13,7 @@ import {
 	CARD_TYPE_NAME,
 	CARD_TYPE_SYMBOL,
 } from "./cardConstants";
-import { drawRoundedRect } from "./graphicsHelpers";
+import { drawRoundedRect, makeInteractive } from "./graphicsHelpers";
 import { UI_COLOR_GOLD, UI_COLORS_DISABLED } from "./uiColors";
 
 /** カード描画定数 */
@@ -356,22 +356,7 @@ export class HandRenderer {
 
 		// インタラクション
 		if (enabled) {
-			cardContainer.eventMode = "static";
-			cardContainer.cursor = "pointer";
-
-			cardContainer.on("pointerover", () => {
-				if (this.hoveredCardId === card.id) return;
-				this.hoveredCardId = card.id;
-				this.render(this.currentHand, this.currentAp);
-			});
-
-			cardContainer.on("pointerout", () => {
-				if (this.hoveredCardId !== card.id) return;
-				this.hoveredCardId = null;
-				this.render(this.currentHand, this.currentAp);
-			});
-
-			cardContainer.on("pointerdown", (event) => {
+			makeInteractive(cardContainer, (event) => {
 				this.animateCardPulse(cardContainer);
 				// 方向パラメータを持つカードの場合、クリック位置から方向を判定
 				if (
@@ -388,6 +373,18 @@ export class HandRenderer {
 				} else {
 					this.onCardSelect?.(card);
 				}
+			});
+
+			cardContainer.on("pointerover", () => {
+				if (this.hoveredCardId === card.id) return;
+				this.hoveredCardId = card.id;
+				this.render(this.currentHand, this.currentAp);
+			});
+
+			cardContainer.on("pointerout", () => {
+				if (this.hoveredCardId !== card.id) return;
+				this.hoveredCardId = null;
+				this.render(this.currentHand, this.currentAp);
 			});
 		}
 


### PR DESCRIPTION
## 概要
- handRenderer.ts の `eventMode`/`cursor`/`pointerdown` の直接設定を `makeInteractive()` ヘルパーに置き換え
- UIコンポーネントのインタラクティブ設定パターンを統一

### 対象外とした箇所
- **turnEndButton.ts**: `drawButton()` は enabled/disabled 切り替え時に呼ばれ、`pointerdown` リスナーはコンストラクタで別途1回だけ登録済み。`makeInteractive` を使うとリスナーが重複登録されるため対象外
- **rewardScreen.ts**: スクロールコンテナの `cursor` は `"grab"` であり、`makeInteractive` が設定する `"pointer"` とは異なるため対象外

Closes #223

## テスト計画
- [x] 既存のユニットテストが全て通ること（492 passed）
- [x] E2Eテストが通ること（1 passed）
- [x] Biome lint/formatが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)