### PR TITLE
feat: デッキシャッフル演出を追加

### DIFF
--- a/frontend/src/game/deck.test.ts
+++ b/frontend/src/game/deck.test.ts
@@ -11,6 +11,7 @@ import {
 	playCard,
 	resetCardIdCounter,
 	reshuffleDeck,
+	willReshuffle,
 } from "./deck";
 
 describe("deck", () => {
@@ -207,6 +208,53 @@ describe("deck", () => {
 				discardPile: [],
 			};
 			expect(getAllCards(deck)).toHaveLength(0);
+		});
+	});
+
+	describe("willReshuffle", () => {
+		it("山札がドロー枚数より少なく捨て札がある場合はtrueを返す", () => {
+			const deck = {
+				drawPile: [{ id: "card-1", type: "move" as const }],
+				hand: [],
+				discardPile: [
+					{ id: "card-2", type: "attack" as const },
+					{ id: "card-3", type: "wait" as const },
+				],
+			};
+			expect(willReshuffle(deck)).toBe(true);
+		});
+
+		it("山札がドロー枚数以上の場合はfalseを返す", () => {
+			const deck = {
+				drawPile: Array.from({ length: HAND_LIMIT }, (_, i) => ({
+					id: `card-${i + 1}`,
+					type: "move" as const,
+				})),
+				hand: [],
+				discardPile: [],
+			};
+			expect(willReshuffle(deck)).toBe(false);
+		});
+
+		it("捨て札が空の場合はfalseを返す", () => {
+			const deck = {
+				drawPile: [{ id: "card-1", type: "move" as const }],
+				hand: [],
+				discardPile: [],
+			};
+			expect(willReshuffle(deck)).toBe(false);
+		});
+
+		it("手札が上限の場合はfalseを返す", () => {
+			const deck = {
+				drawPile: [],
+				hand: Array.from({ length: HAND_LIMIT }, (_, i) => ({
+					id: `card-${i + 1}`,
+					type: "move" as const,
+				})),
+				discardPile: [{ id: "card-99", type: "attack" as const }],
+			};
+			expect(willReshuffle(deck)).toBe(false);
 		});
 	});
 

--- a/frontend/src/game/deck.ts
+++ b/frontend/src/game/deck.ts
@@ -87,6 +87,19 @@ export function createInitialDeckState(rng: RNG): DeckState {
 }
 
 /**
+ * ドロー時に捨て札→山札のリシャッフルが発生するかを判定
+ * アニメーション制御用
+ */
+export function willReshuffle(deck: DeckState, count?: number): boolean {
+	const drawCount = count ?? Math.max(0, HAND_LIMIT - deck.hand.length);
+	return (
+		drawCount > 0 &&
+		deck.drawPile.length < drawCount &&
+		deck.discardPile.length > 0
+	);
+}
+
+/**
  * 山札からカードを引いて手札に加える
  * 山札が不足する場合は捨て札をシャッフルして山札に戻す
  */

--- a/frontend/src/ui/eventHandlers.ts
+++ b/frontend/src/ui/eventHandlers.ts
@@ -13,6 +13,7 @@ import {
 	returnToTitle,
 	startNewGame,
 	startPlayerTurn,
+	willReshuffle,
 } from "../game";
 import type { GameContext } from "../gameContext";
 import type { Direction } from "../types";
@@ -344,6 +345,9 @@ export function setupEventHandlers(ctx: GameContext): void {
 			}
 
 			if (next.screen !== "gameOver") {
+				// リシャッフル判定（startPlayerTurn内のdrawCards前の状態で判定）
+				const needsShuffle = willReshuffle(next.deck);
+
 				next = startPlayerTurn(next);
 
 				// プレイヤーターンバナー表示
@@ -351,6 +355,12 @@ export function setupEventHandlers(ctx: GameContext): void {
 
 				applyState(ctx, next);
 				render(ctx, true);
+
+				// リシャッフル演出（ドロー前に実行）
+				if (needsShuffle) {
+					await ctx.ui.handRenderer.animateShuffle();
+				}
+
 				await ctx.ui.handRenderer.renderWithAnimation(
 					ctx.state.deck.hand,
 					ctx.state.player.ap,

--- a/frontend/src/ui/gameAnimations.ts
+++ b/frontend/src/ui/gameAnimations.ts
@@ -311,7 +311,9 @@ export async function updateStateWithStairsAnimation(
 			await ctx.ui.floorBanner.hide();
 		});
 
-		// 6. フェードイン後に手札配布アニメーション
+		// 6. フェードイン後にシャッフル演出→手札配布アニメーション
+		// 階層遷移時は全デッキリシャッフルが行われるため常にシャッフル演出を表示
+		await ctx.ui.handRenderer.animateShuffle();
 		await ctx.ui.handRenderer.renderWithAnimation(
 			ctx.state.deck.hand,
 			ctx.state.player.ap,
@@ -404,7 +406,9 @@ export async function animateRushWithStairs(
 			await ctx.ui.floorBanner.hide();
 		});
 
-		// 7. フェードイン後に手札配布アニメーション
+		// 7. フェードイン後にシャッフル演出→手札配布アニメーション
+		// 階層遷移時は全デッキリシャッフルが行われるため常にシャッフル演出を表示
+		await ctx.ui.handRenderer.animateShuffle();
 		await ctx.ui.handRenderer.renderWithAnimation(
 			ctx.state.deck.hand,
 			ctx.state.player.ap,

--- a/frontend/src/ui/handRenderer.ts
+++ b/frontend/src/ui/handRenderer.ts
@@ -31,6 +31,18 @@ const DEAL_ANIMATION_DELAY = 80; // カード間のディレイ（ms）
 const DECK_OFFSET_X = -300; // 山札の位置（手札コンテナからの相対X）
 const DECK_OFFSET_Y = -50; // 山札の位置（手札コンテナからの相対Y）
 
+/** シャッフルアニメーション定数 */
+const SHUFFLE_CARD_COUNT = 5; // シャッフル演出で表示するカード枚数
+const SHUFFLE_SCATTER_DURATION = 200; // 散らばるアニメーション時間（ms）
+const SHUFFLE_GATHER_DURATION = 200; // 集まるアニメーション時間（ms）
+const SHUFFLE_SCATTER_DELAY = 30; // カード間のディレイ（ms）
+const SHUFFLE_GATHER_DELAY = 30; // 集まり時のディレイ（ms）
+const SHUFFLE_SCATTER_RANGE_X = 60; // 散らばりのX範囲（px）
+const SHUFFLE_SCATTER_RANGE_Y = 30; // 散らばりのY範囲（px）
+const SHUFFLE_ROTATION_RANGE = 0.3; // 散らばり時の回転範囲（rad）
+const SHUFFLE_CARD_COLOR = 0x445566; // シャッフル演出のカード裏面色
+const SHUFFLE_CARD_BORDER_COLOR = 0x667788; // カード裏面の枠色
+
 /** ホバー時の浮き上がり距離（px） */
 const HOVER_LIFT = 8;
 
@@ -436,6 +448,117 @@ export class HandRenderer {
 			arrowText.y = arrow.y;
 			cardContainer.addChild(arrowText);
 		}
+	}
+
+	/**
+	 * シャッフルアニメーション
+	 * 捨て札→山札リシャッフル時に、山札位置でカードが散らばって集まる演出
+	 * @returns アニメーション完了時にresolveするPromise
+	 */
+	async animateShuffle(): Promise<void> {
+		this.container.removeChildren();
+
+		const cards: Container[] = [];
+
+		// シャッフル演出用のカード裏面を生成
+		for (let i = 0; i < SHUFFLE_CARD_COUNT; i++) {
+			const card = new Container();
+			card.x = DECK_OFFSET_X;
+			card.y = DECK_OFFSET_Y;
+
+			const bg = new Graphics();
+			drawRoundedRect(
+				bg,
+				CARD_WIDTH,
+				CARD_HEIGHT,
+				CARD_RADIUS,
+				SHUFFLE_CARD_COLOR,
+				{ color: SHUFFLE_CARD_BORDER_COLOR, width: 2 },
+			);
+			card.addChild(bg);
+
+			// カード裏面の模様（中央に菱形パターン）
+			const pattern = new Graphics();
+			const cx = CARD_WIDTH / 2;
+			const cy = CARD_HEIGHT / 2;
+			pattern.moveTo(cx, cy - 20);
+			pattern.lineTo(cx + 15, cy);
+			pattern.lineTo(cx, cy + 20);
+			pattern.lineTo(cx - 15, cy);
+			pattern.closePath();
+			pattern.stroke({ color: SHUFFLE_CARD_BORDER_COLOR, width: 1.5 });
+			card.addChild(pattern);
+
+			card.pivot.set(CARD_WIDTH / 2, CARD_HEIGHT / 2);
+			card.x = DECK_OFFSET_X + CARD_WIDTH / 2;
+			card.y = DECK_OFFSET_Y + CARD_HEIGHT / 2;
+			card.alpha = 0;
+
+			this.container.addChild(card);
+			cards.push(card);
+		}
+
+		// 散らばる目標位置を事前計算（対称的な配置）
+		const scatterTargets = cards.map((_, i) => {
+			const angle =
+				((i - Math.floor(SHUFFLE_CARD_COUNT / 2)) /
+					Math.max(SHUFFLE_CARD_COUNT - 1, 1)) *
+				2;
+			return {
+				x: DECK_OFFSET_X + CARD_WIDTH / 2 + angle * SHUFFLE_SCATTER_RANGE_X,
+				y:
+					DECK_OFFSET_Y +
+					CARD_HEIGHT / 2 +
+					(Math.abs(angle) - 1) * SHUFFLE_SCATTER_RANGE_Y,
+				rotation: angle * SHUFFLE_ROTATION_RANGE,
+			};
+		});
+
+		// フェーズ1: 散らばる
+		const scatterPromises = cards.map((card, i) =>
+			tween(
+				card,
+				{
+					x: scatterTargets[i].x,
+					y: scatterTargets[i].y,
+					alpha: 1,
+					rotation: scatterTargets[i].rotation,
+				},
+				{
+					duration: SHUFFLE_SCATTER_DURATION,
+					delay: i * SHUFFLE_SCATTER_DELAY,
+					easing: Easing.easeOutCubic,
+				},
+			),
+		);
+		await Promise.all(scatterPromises);
+
+		// フェーズ2: 集まる
+		const gatherPromises = cards.map((card, i) =>
+			tween(
+				card,
+				{
+					x: DECK_OFFSET_X + CARD_WIDTH / 2,
+					y: DECK_OFFSET_Y + CARD_HEIGHT / 2,
+					alpha: 0.8,
+					rotation: 0,
+				},
+				{
+					duration: SHUFFLE_GATHER_DURATION,
+					delay: i * SHUFFLE_GATHER_DELAY,
+					easing: Easing.easeInOut,
+				},
+			),
+		);
+		await Promise.all(gatherPromises);
+
+		// フェーズ3: フェードアウト
+		const fadePromises = cards.map((card) =>
+			tween(card, { alpha: 0 }, { duration: 100, easing: Easing.easeOut }),
+		);
+		await Promise.all(fadePromises);
+
+		this.container.removeChildren();
 	}
 
 	/**


### PR DESCRIPTION
## 概要
- 捨て札→山札リシャッフル時に、カード裏面が山札位置で散らばって集まるアニメーションを追加
- 階層遷移後の全デッキリシャッフル時にもシャッフル演出を表示
- ターン終了→新ハンド配布時、山札不足によるリシャッフル発生を事前検出して演出を挿入
- シャッフル→ドロー演出が一連の流れとして視覚的に分かるよう統合

## テスト計画
- [ ] ターン終了時、山札が不足する状態でシャッフル演出が表示されることを確認
- [ ] 山札が十分にある場合はシャッフル演出なしでドロー演出のみ表示されることを確認
- [ ] 階段到達時、階層遷移後にシャッフル演出→ドロー演出が順に再生されることを確認
- [ ] 突進で階段到達した場合も同様の演出が再生されることを確認
- [ ] アニメーションのテンポが適切で、ゲームプレイを妨げないことを確認
- [ ] `willReshuffle`関数のユニットテストが全て通ること

closes #233