### PR TITLE
chore: resolve-pr-reviewコマンドの複数PR並列処理対応

### DIFF
--- a/.claude/commands/resolve-pr-review.md
+++ b/.claude/commands/resolve-pr-review.md
@@ -138,7 +138,7 @@ git worktree add /tmp/wt-pr-<番号>
 
 5. **Copilotにレビュー再依頼**:
    ```
-   gh api repos/<owner>/<repo>/pulls/<番号>/requested_reviewers \
+   gh api repos/{owner}/{repo}/pulls/<番号>/requested_reviewers \
      -X POST --raw-field 'reviewers[]=copilot-pull-request-reviewer[bot]'
    ```
    （既にreviewerの場合の `Validation Failed` エラーは無視する）


### PR DESCRIPTION
## 概要

- `/resolve-pr-review` カスタムコマンドに並列処理モードを追加
- 複数PR番号指定時にagent teamとgit worktreeを使ってPRごとに並列作業
- `issue-pr` コマンドと同じパターン（TeamCreate → TaskCreate → worktreeセットアップ → エージェント並列起動 → 後片付け）
- GraphQLクエリ等の共通手順をリファレンスセクションとして末尾に切り出し、両モードから参照可能に
- 単一PR処理モードは既存フローをそのまま維持

## テスト計画

- [ ] `/resolve-pr-review 123` で単一PRの従来フローが動作することを確認
- [ ] `/resolve-pr-review 123 456` で並列処理モードに分岐することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)