### PR TITLE
refactor: カード除去画面とデッキ閲覧画面のカード一覧UIを統一

### DIFF
--- a/src/ui/cardRowRenderer.test.ts
+++ b/src/ui/cardRowRenderer.test.ts
@@ -1,0 +1,97 @@
+import { Container, Text } from "pixi.js";
+import { describe, expect, it } from "vitest";
+import {
+	CARD_EFFECT_TEXT,
+	CARD_TYPE_NAME,
+	CARD_TYPE_SYMBOL,
+} from "./cardConstants";
+import {
+	CARD_ROW_HEIGHT,
+	CARD_ROW_LIST_WIDTH,
+	CARD_ROW_TEXT_X,
+	createCardListRow,
+} from "./cardRowRenderer";
+
+describe("cardRowRenderer", () => {
+	describe("createCardListRow", () => {
+		it("コンテナが生成される", () => {
+			const row = createCardListRow({ cardType: "move" });
+			expect(row).toBeInstanceOf(Container);
+		});
+
+		it("行の高さ定数が52px", () => {
+			expect(CARD_ROW_HEIGHT).toBe(52);
+		});
+
+		it("リスト幅定数が260px", () => {
+			expect(CARD_ROW_LIST_WIDTH).toBe(260);
+		});
+
+		it("テキスト開始X位置定数が16px", () => {
+			expect(CARD_ROW_TEXT_X).toBe(16);
+		});
+
+		it("カード名テキストが含まれる", () => {
+			const row = createCardListRow({ cardType: "attack" });
+			const texts = row.children.filter((c) => c instanceof Text) as Text[];
+			const nameText = texts.find((t) =>
+				t.text.includes(CARD_TYPE_NAME.attack),
+			);
+			expect(nameText).toBeDefined();
+			expect(nameText?.text).toContain(CARD_TYPE_SYMBOL.attack);
+		});
+
+		it("カード名のフォントサイズが15pxでbold", () => {
+			const row = createCardListRow({ cardType: "move" });
+			const texts = row.children.filter((c) => c instanceof Text) as Text[];
+			const nameText = texts.find((t) => t.text.includes(CARD_TYPE_NAME.move));
+			expect(nameText).toBeDefined();
+			expect(nameText?.style.fontSize).toBe(15);
+			expect(nameText?.style.fontWeight).toBe("bold");
+		});
+
+		it("効果テキストが含まれる", () => {
+			const row = createCardListRow({ cardType: "move" });
+			const texts = row.children.filter((c) => c instanceof Text) as Text[];
+			const effectText = texts.find((t) =>
+				t.text.includes(CARD_EFFECT_TEXT.move),
+			);
+			expect(effectText).toBeDefined();
+		});
+
+		it("効果テキストのフォントサイズが11px", () => {
+			const row = createCardListRow({ cardType: "attack" });
+			const texts = row.children.filter((c) => c instanceof Text) as Text[];
+			const effectText = texts.find((t) =>
+				t.text.includes(CARD_EFFECT_TEXT.attack),
+			);
+			expect(effectText).toBeDefined();
+			expect(effectText?.style.fontSize).toBe(11);
+		});
+
+		it("枚数を指定すると名前行に枚数が表示される", () => {
+			const row = createCardListRow({ cardType: "move", count: 3 });
+			const texts = row.children.filter((c) => c instanceof Text) as Text[];
+			const nameText = texts.find((t) => t.text.includes(CARD_TYPE_NAME.move));
+			expect(nameText?.text).toContain("x3");
+		});
+
+		it("枚数を指定しないと枚数表示がない", () => {
+			const row = createCardListRow({ cardType: "move" });
+			const texts = row.children.filter((c) => c instanceof Text) as Text[];
+			const nameText = texts.find((t) => t.text.includes(CARD_TYPE_NAME.move));
+			expect(nameText?.text).not.toContain("x");
+		});
+
+		it("レアリティバーが描画される", () => {
+			const row = createCardListRow({ cardType: "rush" });
+			// 背景 + レアリティバー + 名前テキスト + 効果テキスト = 最低4つの子要素
+			expect(row.children.length).toBeGreaterThanOrEqual(4);
+		});
+
+		it("幅を指定できる", () => {
+			const row = createCardListRow({ cardType: "move", width: 300 });
+			expect(row).toBeInstanceOf(Container);
+		});
+	});
+});

--- a/src/ui/cardRowRenderer.ts
+++ b/src/ui/cardRowRenderer.ts
@@ -1,0 +1,125 @@
+/**
+ * カード行の共通描画ヘルパー
+ * deckViewerとrewardScreenのカード一覧表示を統一するために使用
+ */
+
+import { Container, Graphics, Text } from "pixi.js";
+import { CARD_COST, CARD_RARITY } from "../constants";
+import type { CardType } from "../types";
+import {
+	CARD_COLORS,
+	CARD_EFFECT_TEXT,
+	CARD_TYPE_NAME,
+	CARD_TYPE_SYMBOL,
+	RARITY_COLORS,
+} from "./cardConstants";
+import { drawRoundedRect } from "./graphicsHelpers";
+
+/** カード行の高さ */
+export const CARD_ROW_HEIGHT = 52;
+
+/** カード行の間隔 */
+export const CARD_ROW_GAP = 6;
+
+/** カード行のリスト幅 */
+export const CARD_ROW_LIST_WIDTH = 260;
+
+/** テキスト開始X位置 */
+export const CARD_ROW_TEXT_X = 16;
+
+/** カード行の角丸半径 */
+const ROW_RADIUS = 6;
+
+/** レアリティバー設定 */
+const RARITY_BAR_X = 6;
+const RARITY_BAR_WIDTH = 3;
+const RARITY_BAR_PADDING = 4;
+const RARITY_BAR_RADIUS = 1;
+
+/** フォント設定 */
+const NAME_FONT_SIZE = 15;
+const EFFECT_FONT_SIZE = 11;
+const NAME_Y = 8;
+const EFFECT_Y = 30;
+
+type CardListRowOptions = {
+	/** カード種別 */
+	cardType: CardType;
+	/** 枚数（省略時は枚数表示なし） */
+	count?: number;
+	/** 行の幅（デフォルト: CARD_ROW_LIST_WIDTH） */
+	width?: number;
+};
+
+/**
+ * カード一覧の1行を生成する共通ヘルパー
+ *
+ * 背景 + レアリティバー + カード名（シンボル付き） + 効果テキスト を描画する。
+ * 追加のUI要素（除去ボタン等）は呼び出し側でコンテナに追加する。
+ */
+export function createCardListRow(options: CardListRowOptions): Container {
+	const { cardType, count, width = CARD_ROW_LIST_WIDTH } = options;
+	const row = new Container();
+
+	const colors = CARD_COLORS[cardType];
+	const rarity = CARD_RARITY[cardType];
+	const rarityColor = RARITY_COLORS[rarity];
+
+	// 背景
+	const bg = new Graphics();
+	drawRoundedRect(bg, width, CARD_ROW_HEIGHT, ROW_RADIUS, colors.bg, {
+		color: colors.border,
+		width: 1,
+	});
+	row.addChild(bg);
+
+	// レアリティバー
+	const rarityBar = new Graphics();
+	rarityBar.roundRect(
+		RARITY_BAR_X,
+		RARITY_BAR_PADDING,
+		RARITY_BAR_WIDTH,
+		CARD_ROW_HEIGHT - RARITY_BAR_PADDING * 2,
+		RARITY_BAR_RADIUS,
+	);
+	rarityBar.fill(rarityColor);
+	row.addChild(rarityBar);
+
+	// シンボル + 種別名（+ 枚数）
+	const nameStr =
+		count != null
+			? `${CARD_TYPE_SYMBOL[cardType]} ${CARD_TYPE_NAME[cardType]} x${count}`
+			: `${CARD_TYPE_SYMBOL[cardType]} ${CARD_TYPE_NAME[cardType]}`;
+	const nameText = new Text({
+		text: nameStr,
+		style: {
+			fontSize: NAME_FONT_SIZE,
+			fontFamily: "sans-serif",
+			fill: 0xffffff,
+			fontWeight: "bold",
+		},
+	});
+	nameText.x = CARD_ROW_TEXT_X;
+	nameText.y = NAME_Y;
+	row.addChild(nameText);
+
+	// AP + 効果テキスト
+	const cost = CARD_COST[cardType];
+	const effectStr =
+		cost > 0
+			? `${CARD_EFFECT_TEXT[cardType]} / AP: ${cost}`
+			: CARD_EFFECT_TEXT[cardType];
+	const effectText = new Text({
+		text: effectStr,
+		style: {
+			fontSize: EFFECT_FONT_SIZE,
+			fontFamily: "sans-serif",
+			fill: 0xaaaaaa,
+		},
+	});
+	effectText.x = CARD_ROW_TEXT_X;
+	effectText.y = EFFECT_Y;
+	row.addChild(effectText);
+
+	return row;
+}

--- a/src/ui/deckViewer.ts
+++ b/src/ui/deckViewer.ts
@@ -4,16 +4,14 @@
  */
 
 import { Container, Graphics, Text } from "pixi.js";
-import { CARD_COST, CARD_RARITY } from "../constants";
 import { getAllCards, getTotalDeckSize } from "../game/deck";
 import type { CardType, DeckState } from "../types";
 import {
-	CARD_COLORS,
-	CARD_EFFECT_TEXT,
-	CARD_TYPE_NAME,
-	CARD_TYPE_SYMBOL,
-	RARITY_COLORS,
-} from "./cardConstants";
+	CARD_ROW_GAP,
+	CARD_ROW_HEIGHT,
+	CARD_ROW_LIST_WIDTH,
+	createCardListRow,
+} from "./cardRowRenderer";
 import {
 	createOverlay,
 	drawRoundedRect,
@@ -21,10 +19,6 @@ import {
 } from "./graphicsHelpers";
 import { BUTTON_HEIGHT, DECK_BUTTON_WIDTH } from "./layout";
 import { UI_COLOR_GOLD, UI_COLORS_BUTTON_SECONDARY } from "./uiColors";
-
-/** カード行の高さ・間隔 */
-const CARD_ROW_HEIGHT = 52;
-const CARD_ROW_GAP = 6;
 
 /** 閉じるボタンサイズ */
 const CLOSE_BUTTON_WIDTH = 100;
@@ -154,8 +148,7 @@ export class DeckViewer {
 		this.container.addChild(title);
 
 		// カード種別リスト
-		const listWidth = 260;
-		const listX = (screenWidth - listWidth) / 2;
+		const listX = (screenWidth - CARD_ROW_LIST_WIDTH) / 2;
 		const listStartY = 60;
 
 		const types = CARD_TYPE_ORDER.filter((t) => (cardCounts.get(t) ?? 0) > 0);
@@ -164,7 +157,9 @@ export class DeckViewer {
 			const cardType = types[i];
 			const count = cardCounts.get(cardType) ?? 0;
 			const y = listStartY + i * (CARD_ROW_HEIGHT + CARD_ROW_GAP);
-			const row = this.createCardRow(cardType, count, listX, y, listWidth);
+			const row = createCardListRow({ cardType, count });
+			row.x = listX;
+			row.y = y;
 			this.container.addChild(row);
 		}
 
@@ -185,73 +180,6 @@ export class DeckViewer {
 			counts.set(card.type, (counts.get(card.type) ?? 0) + 1);
 		}
 		return counts;
-	}
-
-	/**
-	 * カード種別の1行を生成
-	 */
-	private createCardRow(
-		cardType: CardType,
-		count: number,
-		x: number,
-		y: number,
-		width: number,
-	): Container {
-		const row = new Container();
-		row.x = x;
-		row.y = y;
-
-		const colors = CARD_COLORS[cardType];
-		const rarity = CARD_RARITY[cardType];
-		const rarityColor = RARITY_COLORS[rarity];
-
-		// 背景
-		const bg = new Graphics();
-		drawRoundedRect(bg, width, CARD_ROW_HEIGHT, 6, colors.bg, {
-			color: colors.border,
-			width: 1,
-		});
-		row.addChild(bg);
-
-		// レアリティバー
-		const rarityBar = new Graphics();
-		rarityBar.roundRect(6, 4, 3, CARD_ROW_HEIGHT - 8, 1);
-		rarityBar.fill(rarityColor);
-		row.addChild(rarityBar);
-
-		// シンボル + 種別名 + 枚数
-		const nameText = new Text({
-			text: `${CARD_TYPE_SYMBOL[cardType]} ${CARD_TYPE_NAME[cardType]} x${count}`,
-			style: {
-				fontSize: 15,
-				fontFamily: "sans-serif",
-				fill: 0xffffff,
-				fontWeight: "bold",
-			},
-		});
-		nameText.x = 16;
-		nameText.y = 8;
-		row.addChild(nameText);
-
-		// AP + 効果テキスト
-		const cost = CARD_COST[cardType];
-		const effectStr =
-			cost > 0
-				? `${CARD_EFFECT_TEXT[cardType]} / AP: ${cost}`
-				: CARD_EFFECT_TEXT[cardType];
-		const effectText = new Text({
-			text: effectStr,
-			style: {
-				fontSize: 11,
-				fontFamily: "sans-serif",
-				fill: 0xaaaaaa,
-			},
-		});
-		effectText.x = 16;
-		effectText.y = 30;
-		row.addChild(effectText);
-
-		return row;
 	}
 
 	/**

--- a/src/ui/rewardScreen.ts
+++ b/src/ui/rewardScreen.ts
@@ -15,6 +15,12 @@ import {
 	RARITY_COLORS,
 } from "./cardConstants";
 import {
+	CARD_ROW_GAP,
+	CARD_ROW_HEIGHT,
+	CARD_ROW_LIST_WIDTH,
+	createCardListRow,
+} from "./cardRowRenderer";
+import {
 	createOverlay,
 	drawRoundedRect,
 	makeInteractive,
@@ -60,8 +66,6 @@ const REMOVE_PARTICLE_COLORS = [0xff4444, 0xff6644, 0xcc2222];
 const REMOVE_PARTICLE_COUNT = 15;
 
 /** 除去モードのカード一覧設定 */
-const REMOVE_CARD_HEIGHT = 28;
-const REMOVE_CARD_GAP = 4;
 const REMOVE_LIST_MAX_HEIGHT = 300;
 
 /**
@@ -182,21 +186,20 @@ export class RewardScreen {
 
 		// スクロール可能なカード一覧
 		const listStartY = 60;
-		const listWidth = 240;
-		const listX = (screenWidth - listWidth) / 2;
+		const listX = (screenWidth - CARD_ROW_LIST_WIDTH) / 2;
 		const totalListHeight =
 			deckCards.length === 0
 				? 0
-				: deckCards.length * REMOVE_CARD_HEIGHT +
-					(deckCards.length - 1) * REMOVE_CARD_GAP;
+				: deckCards.length * CARD_ROW_HEIGHT +
+					(deckCards.length - 1) * CARD_ROW_GAP;
 
 		// スクロールコンテナ
 		this.scrollContainer = new Container();
 		const scrollContainer = this.scrollContainer;
 		for (let i = 0; i < deckCards.length; i++) {
 			const card = deckCards[i];
-			const y = i * (REMOVE_CARD_HEIGHT + REMOVE_CARD_GAP);
-			const item = this.createRemoveCardItem(card, 0, y, listWidth);
+			const y = i * (CARD_ROW_HEIGHT + CARD_ROW_GAP);
+			const item = this.createRemoveCardItem(card, 0, y, CARD_ROW_LIST_WIDTH);
 			scrollContainer.addChild(item);
 		}
 		scrollContainer.x = listX;
@@ -206,7 +209,7 @@ export class RewardScreen {
 		// PixiJS v8ではマスクをディスプレイリストに追加せず参照のみ保持する
 		const visibleHeight = Math.min(REMOVE_LIST_MAX_HEIGHT, totalListHeight);
 		const maskGraphics = new Graphics();
-		maskGraphics.rect(listX, listStartY, listWidth, visibleHeight);
+		maskGraphics.rect(listX, listStartY, CARD_ROW_LIST_WIDTH, visibleHeight);
 		maskGraphics.fill(0xffffff);
 		scrollContainer.mask = maskGraphics;
 		this.container.addChild(scrollContainer);
@@ -403,42 +406,16 @@ export class RewardScreen {
 		y: number,
 		width: number,
 	): Container {
-		const item = new Container();
+		const item = createCardListRow({ cardType: card.type, width });
 		item.x = x;
 		item.y = y;
-
-		// 背景
-		const bg = new Graphics();
-		drawRoundedRect(
-			bg,
-			width,
-			REMOVE_CARD_HEIGHT,
-			4,
-			CARD_COLORS[card.type].bg,
-			{ color: CARD_COLORS[card.type].border, width: 1 },
-		);
-		item.addChild(bg);
-
-		// カード名
-		const nameLabel = new Text({
-			text: `${CARD_TYPE_SYMBOL[card.type]} ${CARD_TYPE_NAME[card.type]}`,
-			style: {
-				fontSize: 13,
-				fontFamily: "sans-serif",
-				fill: 0xffffff,
-			},
-		});
-		nameLabel.anchor.set(0, 0.5);
-		nameLabel.x = 8;
-		nameLabel.y = REMOVE_CARD_HEIGHT / 2;
-		item.addChild(nameLabel);
 
 		// 除去ボタン
 		const removeBtnWidth = 50;
 		const removeBtnHeight = 22;
 		const removeBtn = new Container();
 		removeBtn.x = width - removeBtnWidth - 6;
-		removeBtn.y = (REMOVE_CARD_HEIGHT - removeBtnHeight) / 2;
+		removeBtn.y = (CARD_ROW_HEIGHT - removeBtnHeight) / 2;
 
 		const removeBg = new Graphics();
 		drawRoundedRect(removeBg, removeBtnWidth, removeBtnHeight, 4, 0x882222, {
@@ -601,7 +578,7 @@ export class RewardScreen {
 		// アイテム中心のグローバル座標をパーティクルシステムのローカル座標に変換
 		const globalPos = itemContainer.toGlobal({
 			x: itemWidth / 2,
-			y: REMOVE_CARD_HEIGHT / 2,
+			y: CARD_ROW_HEIGHT / 2,
 		});
 		const particleOrigin = this.particleSystem
 			? this.particleSystem.getContainer().toLocal(globalPos)


### PR DESCRIPTION
## 概要
- カード行描画の共通ヘルパー `createCardListRow` を `cardRowRenderer.ts` に抽出
- 除去選択画面（rewardScreen）のカード行をデッキ閲覧画面（deckViewer）のスタイルに統一
  - 行高さ: 28px → 52px
  - フォントサイズ: 13px → 15px bold
  - 効果テキスト（APコスト含む）を除去選択画面にも追加
  - レアリティバーを除去選択画面にも追加
  - 左パディング: 8px → 16px
  - リスト幅: 240px → 260px
- deckViewer の `createCardRow` を共通ヘルパーに置き換え、重複コードを削減

Closes #264

## テスト計画
- [x] `cardRowRenderer.test.ts`: 共通ヘルパーの単体テスト（定数値、テキスト内容、スタイル）
- [x] `deckViewer.test.ts`: 既存テスト全パス
- [x] `rewardScreen.test.ts`: 既存テスト全パス（除去ボタン、スキップ、アニメーション）
- [x] ビルド成功
- [x] E2Eテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)