### PR TITLE
feat: マウス右クリックでターン終了できるようにする

### DIFF
--- a/src/ui/eventHandlers.ts
+++ b/src/ui/eventHandlers.ts
@@ -614,7 +614,7 @@ export function setupEventHandlers(ctx: GameContext): void {
 	// ターン終了ボタンのコールバック設定
 	ctx.ui.turnEndButton.setOnEndTurn(() => {
 		void handleEndTurn().catch((error) => {
-			console.error(error);
+			console.error("ターン終了ボタンの処理に失敗しました", error);
 		});
 	});
 
@@ -624,7 +624,7 @@ export function setupEventHandlers(ctx: GameContext): void {
 		if (ctx.state.turn !== "player") return;
 		e.preventDefault();
 		void handleEndTurn().catch((error) => {
-			console.error(error);
+			console.error("右クリックによるターン終了処理に失敗しました", error);
 		});
 	});
 }


### PR DESCRIPTION
## 概要
- ゲーム画面上でマウス右クリックした際に「ターン終了」と同じ動作を実行する機能を追加
- ターン終了のロジックを`handleEndTurn`関数に抽出し、ボタンと右クリックの両方から呼び出すよう変更
- 右クリック時のブラウザデフォルトコンテキストメニューを`preventDefault()`で抑制
- ゲーム画面(`screen === "game"`)かつプレイヤーターン中(`turn === "player"`)のみ有効
- 既存の「ターン終了」ボタンはそのまま維持
- アニメーション中は既存の`isAnimating`フラグにより無効化される

Closes #273

## テスト計画
- [ ] ゲーム画面で右クリックしてターン終了が実行されることを確認
- [ ] タイトル画面・ゲームオーバー画面では右クリックが無効であることを確認
- [ ] 敵ターン中は右クリックが無効であることを確認
- [ ] アニメーション中は右クリックが無効であることを確認
- [ ] 既存の「ターン終了」ボタンが引き続き動作することを確認
- [ ] 右クリックでブラウザコンテキストメニューが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)