### PR TITLE
refactor: reward.tsの不要なgetTotalDeckSize再export削除

### DIFF
--- a/src/game/reward.test.ts
+++ b/src/game/reward.test.ts
@@ -2,11 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { DECK_MIN_SIZE, getEnemyCount, INITIAL_FLOOR } from "../constants";
 import { createTestState } from "../test-utils/createTestFixtures";
 import type { Card } from "../types";
-import { resetCardIdCounter } from "./deck";
+import { getTotalDeckSize, resetCardIdCounter } from "./deck";
 import {
 	addRewardCardToDeck,
 	createRewardState,
-	getTotalDeckSize,
 	removeCardFromDeck,
 	shouldTriggerCardRemoval,
 } from "./reward";

--- a/src/game/reward.ts
+++ b/src/game/reward.ts
@@ -12,8 +12,6 @@ import type { CardType, GameState, RewardState } from "../types";
 import { generateRewardChoices } from "./cardPool";
 import { createCard, getTotalDeckSize } from "./deck";
 
-export { getTotalDeckSize };
-
 /**
  * 報酬状態を生成する
  *


### PR DESCRIPTION
## 概要
- `reward.ts` から `getTotalDeckSize` の不要な再exportを削除
- `reward.test.ts` の `getTotalDeckSize` importを `./deck` から直接importに変更
- barrel export (`game/index.ts`) が `deck.ts` と `reward.ts` を両方exportしているため、再exportは冗長だった

Closes #296

## テスト計画
- [x] 既存ユニットテスト全778件がパス
- [x] E2Eテストがパス
- [x] TypeScriptビルドが成功
- [x] Biome lint/formatチェックがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)