### PR TITLE
fix: カード選択を左クリックのみに制限し右クリック競合を修正

### DIFF
--- a/src/ui/deckViewer.test.ts
+++ b/src/ui/deckViewer.test.ts
@@ -130,10 +130,9 @@ describe("DeckViewer", () => {
 			// 最後の子要素が閉じるボタン
 			const closeBtn = container.children[container.children.length - 1];
 			expect(closeBtn.eventMode).toBe("static");
-			closeBtn.emit(
-				"pointerdown",
-				{} as import("pixi.js").FederatedPointerEvent,
-			);
+			closeBtn.emit("pointerdown", {
+				button: 0,
+			} as import("pixi.js").FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalled();
 		});
@@ -155,7 +154,9 @@ describe("DeckViewer", () => {
 			const btnContainer = viewer.getButtonContainer();
 			const button = btnContainer.children[0];
 			expect(button.eventMode).toBe("static");
-			button.emit("pointerdown", {} as import("pixi.js").FederatedPointerEvent);
+			button.emit("pointerdown", {
+				button: 0,
+			} as import("pixi.js").FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalled();
 		});

--- a/src/ui/graphicsHelpers.test.ts
+++ b/src/ui/graphicsHelpers.test.ts
@@ -131,7 +131,10 @@ describe("makeInteractive", () => {
 
 		makeInteractive(container, onClick);
 
-		expect(container.on).toHaveBeenCalledWith("pointerdown", onClick);
+		expect(container.on).toHaveBeenCalledWith(
+			"pointerdown",
+			expect.any(Function),
+		);
 	});
 
 	it("コールバックにFederatedPointerEventが渡される", () => {
@@ -141,6 +144,7 @@ describe("makeInteractive", () => {
 		makeInteractive(container, onClick);
 
 		const mockEvent = {
+			button: 0,
 			stopPropagation: vi.fn(),
 		} as unknown as FederatedPointerEvent;
 		const registeredCallback = container.on.mock.calls[0][1] as (
@@ -149,5 +153,41 @@ describe("makeInteractive", () => {
 		registeredCallback(mockEvent);
 
 		expect(onClick).toHaveBeenCalledWith(mockEvent);
+	});
+
+	it("右クリック（button=2）ではコールバックを呼ばない", () => {
+		const container = createMockContainer();
+		const onClick = vi.fn();
+
+		makeInteractive(container, onClick);
+
+		const mockEvent = {
+			button: 2,
+			stopPropagation: vi.fn(),
+		} as unknown as FederatedPointerEvent;
+		const registeredCallback = container.on.mock.calls[0][1] as (
+			e: FederatedPointerEvent,
+		) => void;
+		registeredCallback(mockEvent);
+
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it("中クリック（button=1）ではコールバックを呼ばない", () => {
+		const container = createMockContainer();
+		const onClick = vi.fn();
+
+		makeInteractive(container, onClick);
+
+		const mockEvent = {
+			button: 1,
+			stopPropagation: vi.fn(),
+		} as unknown as FederatedPointerEvent;
+		const registeredCallback = container.on.mock.calls[0][1] as (
+			e: FederatedPointerEvent,
+		) => void;
+		registeredCallback(mockEvent);
+
+		expect(onClick).not.toHaveBeenCalled();
 	});
 });

--- a/src/ui/graphicsHelpers.ts
+++ b/src/ui/graphicsHelpers.ts
@@ -50,5 +50,8 @@ export function makeInteractive(
 ): void {
 	target.eventMode = "static";
 	target.cursor = "pointer";
-	target.on("pointerdown", onClick);
+	target.on("pointerdown", (event: FederatedPointerEvent) => {
+		if (event.button !== 0) return;
+		onClick(event);
+	});
 }

--- a/src/ui/handRenderer.test.ts
+++ b/src/ui/handRenderer.test.ts
@@ -214,6 +214,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		// waitカード（方向なし）をクリック
 		const card2 = findCardContainer(renderer, 2);
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -236,6 +237,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		const card2 = findCardContainer(renderer, 2);
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -259,6 +261,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		const card2 = findCardContainer(renderer, 2);
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -298,6 +301,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		const card2 = findCardContainer(renderer, 2);
 		// 1回目のクリック
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -310,6 +314,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		// 2回目のクリックを試行（isInputLockedガードで早期return）
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -349,6 +354,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		// 1回目のクリックで入力ロック
 		const card0 = findCardContainer(renderer, 0);
 		card0.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -365,6 +371,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		// クリックしてもtweenは増えない（ロック維持）
 		const card0After = findCardContainer(renderer, 0);
 		card0After.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 		expect(mockedTween.mock.calls.length).toBe(tweenCountAfterFirst);
@@ -393,6 +400,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		const card2 = findCardContainer(renderer, 2);
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -405,6 +413,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		// アニメーション中は2回目のクリックが無視される
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 		expect(mockedTween.mock.calls.length).toBe(tweenCountAfterFirst);
@@ -420,6 +429,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		// render()で再描画されるので新しいカードコンテナを取得
 		const card2After = findCardContainer(renderer, 2);
 		card2After.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 		expect(mockedTween.mock.calls.length).toBeGreaterThan(tweenCountAfterFirst);
@@ -446,6 +456,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		// → animateCardConsume完了 → invokeCallback呼び出し → 非同期コールバック保留
 		const card2 = findCardContainer(renderer, 2);
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 
@@ -458,6 +469,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		// コールバックのPromise未解決中は入力ロックが維持される
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 		expect(mockedTween.mock.calls.length).toBe(tweenCountAfterFirst);
@@ -475,6 +487,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 		// 再描画完了後に、改めて新しいカードコンテナを取得してクリック
 		const card2After = findCardContainer(renderer, 2);
 		card2After.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 		expect(mockedTween.mock.calls.length).toBeGreaterThan(tweenCountAfterFirst);
@@ -499,6 +512,7 @@ describe("HandRenderer ホバー・選択演出", () => {
 
 		const card2 = findCardContainer(renderer, 2);
 		card2.emit("pointerdown", {
+			button: 0,
 			global: { x: 0, y: 0 },
 		} as FederatedPointerEvent);
 

--- a/src/ui/nextFloorButton.test.ts
+++ b/src/ui/nextFloorButton.test.ts
@@ -48,7 +48,9 @@ describe("NextFloorButton", () => {
 
 			const container = button.getContainer();
 			const buttonContainer = container.children[0];
-			buttonContainer.emit("pointerdown", {} as FederatedPointerEvent);
+			buttonContainer.emit("pointerdown", {
+				button: 0,
+			} as FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalledTimes(1);
 		});

--- a/src/ui/rewardScreen.test.ts
+++ b/src/ui/rewardScreen.test.ts
@@ -119,13 +119,13 @@ describe("RewardScreen", () => {
 			const container = screen.getContainer();
 			// children[2]がカードコンテナ（クリック可能）
 			const cardContainer = container.children[2];
-			cardContainer.emit("pointerdown", {} as FederatedPointerEvent);
+			cardContainer.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			// 獲得ボタンを探す
 			const acquireBtn = findByLabel(container, "acquireBtn");
 			expect(acquireBtn).toBeDefined();
 			expect(acquireBtn?.eventMode).toBe("static");
-			acquireBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			acquireBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalledWith(0);
 		});
@@ -149,7 +149,9 @@ describe("RewardScreen", () => {
 			expect(acquireBtn?.eventMode).toBe("none");
 
 			// カードをクリック
-			container.children[2].emit("pointerdown", {} as FederatedPointerEvent);
+			container.children[2].emit("pointerdown", {
+				button: 0,
+			} as FederatedPointerEvent);
 			expect(acquireBtn?.eventMode).toBe("static");
 		});
 	});
@@ -162,7 +164,7 @@ describe("RewardScreen", () => {
 			const container = screen.getContainer();
 			const card0 = container.children[2] as Container;
 
-			card0.emit("pointerdown", {} as FederatedPointerEvent);
+			card0.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			const highlight = card0.children.find((c) => c.label === "highlight");
 			expect(highlight).toBeDefined();
@@ -177,11 +179,11 @@ describe("RewardScreen", () => {
 			const card1 = container.children[3] as Container;
 
 			// 1枚目を選択
-			card0.emit("pointerdown", {} as FederatedPointerEvent);
+			card0.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 			expect(card0.children.find((c) => c.label === "highlight")).toBeDefined();
 
 			// 2枚目を選択
-			card1.emit("pointerdown", {} as FederatedPointerEvent);
+			card1.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 			expect(
 				card0.children.find((c) => c.label === "highlight"),
 			).toBeUndefined();
@@ -199,7 +201,7 @@ describe("RewardScreen", () => {
 			const container = screen.getContainer();
 			const skipBtn = findByLabel(container, "skipBtn");
 			expect(skipBtn).toBeDefined();
-			skipBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			skipBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalled();
 		});
@@ -280,13 +282,13 @@ describe("RewardScreen", () => {
 			) as Container;
 			expect(scrollContainer).toBeDefined();
 			const firstItem = scrollContainer.children[0] as Container;
-			firstItem.emit("pointertap", {} as FederatedPointerEvent);
+			firstItem.emit("pointertap", { button: 0 } as FederatedPointerEvent);
 
 			// 除去ボタンをクリック
 			const removeBtn = findByLabel(container, "removeBtn");
 			expect(removeBtn).toBeDefined();
 			expect(removeBtn?.eventMode).toBe("static");
-			removeBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			removeBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			// animateCardRemoveが非同期のためmicrotask flush
 			await vi.waitFor(() => {
@@ -317,7 +319,7 @@ describe("RewardScreen", () => {
 				(c) => "mask" in c && c.mask != null,
 			) as Container;
 			const firstItem = scrollContainer.children[0] as Container;
-			firstItem.emit("pointertap", {} as FederatedPointerEvent);
+			firstItem.emit("pointertap", { button: 0 } as FederatedPointerEvent);
 
 			expect(removeBtn?.eventMode).toBe("static");
 		});
@@ -331,7 +333,7 @@ describe("RewardScreen", () => {
 				(c) => "mask" in c && c.mask != null,
 			) as Container;
 			const firstItem = scrollContainer.children[0] as Container;
-			firstItem.emit("pointertap", {} as FederatedPointerEvent);
+			firstItem.emit("pointertap", { button: 0 } as FederatedPointerEvent);
 
 			const highlight = firstItem.children.find((c) => c.label === "highlight");
 			expect(highlight).toBeDefined();
@@ -348,10 +350,10 @@ describe("RewardScreen", () => {
 			const item0 = scrollContainer.children[0] as Container;
 			const item1 = scrollContainer.children[1] as Container;
 
-			item0.emit("pointertap", {} as FederatedPointerEvent);
+			item0.emit("pointertap", { button: 0 } as FederatedPointerEvent);
 			expect(item0.children.find((c) => c.label === "highlight")).toBeDefined();
 
-			item1.emit("pointertap", {} as FederatedPointerEvent);
+			item1.emit("pointertap", { button: 0 } as FederatedPointerEvent);
 			expect(
 				item0.children.find((c) => c.label === "highlight"),
 			).toBeUndefined();
@@ -367,7 +369,7 @@ describe("RewardScreen", () => {
 			const container = screen.getContainer();
 			const skipBtn = findByLabel(container, "skipBtn");
 			expect(skipBtn).toBeDefined();
-			skipBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			skipBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalled();
 		});
@@ -418,14 +420,13 @@ describe("RewardScreen", () => {
 			const scrollContainer = container.children.find(
 				(c) => "mask" in c && c.mask != null,
 			) as Container;
-			scrollContainer.children[0].emit(
-				"pointertap",
-				{} as FederatedPointerEvent,
-			);
+			scrollContainer.children[0].emit("pointertap", {
+				button: 0,
+			} as FederatedPointerEvent);
 
 			// 除去ボタンをクリック
 			const removeBtn = findByLabel(container, "removeBtn");
-			removeBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			removeBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			// tween/emitは非同期なのでmicrotask flush
 			await vi.waitFor(() => {
@@ -448,14 +449,13 @@ describe("RewardScreen", () => {
 			const scrollContainer = container.children.find(
 				(c) => "mask" in c && c.mask != null,
 			) as Container;
-			scrollContainer.children[0].emit(
-				"pointertap",
-				{} as FederatedPointerEvent,
-			);
+			scrollContainer.children[0].emit("pointertap", {
+				button: 0,
+			} as FederatedPointerEvent);
 
 			// 除去ボタンをクリック
 			const removeBtn = findByLabel(container, "removeBtn");
-			removeBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			removeBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			// confirmButtonContainerのinteractiveChildrenがfalseになる
 			const confirmContainer = container.children.find(
@@ -479,14 +479,13 @@ describe("RewardScreen", () => {
 			const scrollContainer = container.children.find(
 				(c) => "mask" in c && c.mask != null,
 			) as Container;
-			scrollContainer.children[0].emit(
-				"pointertap",
-				{} as FederatedPointerEvent,
-			);
+			scrollContainer.children[0].emit("pointertap", {
+				button: 0,
+			} as FederatedPointerEvent);
 
 			// 除去ボタンをクリック
 			const removeBtn = findByLabel(container, "removeBtn");
-			removeBtn?.emit("pointerdown", {} as FederatedPointerEvent);
+			removeBtn?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 
 			// スクロールコンテナのinteractiveChildrenがfalseになる
 			expect(scrollContainer?.interactiveChildren).toBe(false);

--- a/src/ui/turnEndButton.test.ts
+++ b/src/ui/turnEndButton.test.ts
@@ -57,7 +57,9 @@ describe("TurnEndButton", () => {
 
 			const container = button.getContainer();
 			const buttonContainer = container.children[0];
-			buttonContainer.emit("pointerdown", {} as FederatedPointerEvent);
+			buttonContainer.emit("pointerdown", {
+				button: 0,
+			} as FederatedPointerEvent);
 
 			expect(callback).toHaveBeenCalledTimes(1);
 		});

--- a/src/ui/victoryScreen.test.ts
+++ b/src/ui/victoryScreen.test.ts
@@ -107,7 +107,9 @@ describe("VictoryScreen", () => {
 			screen.render(20, 400, 600);
 			const continueButton = findButtonByLabel(screen.getContainer(), "続ける");
 			expect(continueButton).toBeDefined();
-			continueButton?.emit("pointerdown", {} as FederatedPointerEvent);
+			continueButton?.emit("pointerdown", {
+				button: 0,
+			} as FederatedPointerEvent);
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
 
@@ -120,7 +122,7 @@ describe("VictoryScreen", () => {
 				"タイトルに戻る",
 			);
 			expect(returnButton).toBeDefined();
-			returnButton?.emit("pointerdown", {} as FederatedPointerEvent);
+			returnButton?.emit("pointerdown", { button: 0 } as FederatedPointerEvent);
 			expect(callback).toHaveBeenCalledTimes(1);
 		});
 	});


### PR DESCRIPTION
## 概要
- `makeInteractive`の`pointerdown`ハンドラに`event.button === 0`（左ボタン）のガードを追加
- 右クリック（button=2）や中クリック（button=1）ではコールバックが発火しないように変更
- 既存テスト全箇所のモックイベントに`button: 0`を追加して左クリックを明示

Closes #303

## テスト計画
- [x] `makeInteractive`の右クリック・中クリック無視テスト追加（2件）
- [x] 既存テスト33箇所のモックイベントに`button: 0`を追加
- [x] 全780テスト通過
- [x] E2Eテスト通過
- [x] ビルド・リント・フォーマット通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)