### PR TITLE
feat: カメラ追従を移動完了後のスムーズアニメーションに変更

### DIFF
--- a/src/ui/gameAnimations.ts
+++ b/src/ui/gameAnimations.ts
@@ -87,13 +87,17 @@ export async function updateStateWithMoveAnimation(
 
 	applyState(ctx, newState);
 
+	// render後の新しいカメラ位置（失敗時もfinallyでスナップするためtryの外で保持）
+	let newCameraX = savedCameraX;
+	let newCameraY = savedCameraY;
+
 	try {
 		// プレイヤー以外を描画（renderでカメラが新位置にジャンプする）
 		render(ctx, false, true);
 
 		// render後の新しいカメラ位置を取得し、移動中は旧位置に復元
-		const newCameraX = mapContainer.x;
-		const newCameraY = mapContainer.y;
+		newCameraX = mapContainer.x;
+		newCameraY = mapContainer.y;
 		mapContainer.x = savedCameraX;
 		mapContainer.y = savedCameraY;
 
@@ -126,6 +130,9 @@ export async function updateStateWithMoveAnimation(
 			});
 		}
 	} finally {
+		// アニメーション失敗時もカメラを正しい位置にスナップ
+		mapContainer.x = newCameraX;
+		mapContainer.y = newCameraY;
 		ctx.isAnimating = false;
 	}
 }


### PR DESCRIPTION
## 概要
- プレイヤー移動アニメーション中はカメラ位置を固定し、移動完了後に250msのtweenでスムーズに追従するよう変更
- render前にmapContainerの座標を保存し、render後に復元することでカメラジャンプを防止
- カメラオフセットに変化がない場合（小さいマップ等）はtweenをスキップ

Closes #307

## テスト計画
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全804テスト通過
- [ ] 大きいマップ（4F以降）でプレイヤー移動時にカメラが固定されていること
- [ ] 移動完了後にカメラがスムーズに追従すること
- [ ] 小さいマップ（1-2F）で不要なカメラアニメーションが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)