### PR TITLE
feat: 方向選択UIのボタンデザインを改善

### DIFF
--- a/src/ui/directionSelector.test.ts
+++ b/src/ui/directionSelector.test.ts
@@ -1,0 +1,106 @@
+import type { FederatedPointerEvent } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { DirectionSelector } from "./directionSelector";
+
+describe("DirectionSelector", () => {
+	describe("コンストラクタ", () => {
+		it("コンテナを作成する", () => {
+			const selector = new DirectionSelector();
+			expect(selector.getContainer()).toBeDefined();
+		});
+
+		it("初期状態では非表示", () => {
+			const selector = new DirectionSelector();
+			expect(selector.isVisible()).toBe(false);
+		});
+	});
+
+	describe("show/hide", () => {
+		it("showで表示状態になる", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+			expect(selector.isVisible()).toBe(true);
+		});
+
+		it("hideで非表示状態になる", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+			selector.hide();
+			expect(selector.isVisible()).toBe(false);
+		});
+
+		it("showで方向ボタン4つ+キャンセルボタン1つ=5つの子要素が生成される", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+			expect(selector.getContainer().children.length).toBe(5);
+		});
+
+		it("hideで子要素がクリアされる", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+			selector.hide();
+			expect(selector.getContainer().children.length).toBe(0);
+		});
+	});
+
+	describe("方向選択コールバック", () => {
+		it("方向ボタンクリックでコールバックが呼ばれる", () => {
+			const selector = new DirectionSelector();
+			const callback = vi.fn();
+			selector.setOnDirectionSelect(callback);
+			selector.show();
+
+			// 最初のボタン（up）をクリック
+			const upButton = selector.getContainer().children[0];
+			upButton.emit("pointerdown", {
+				button: 0,
+			} as FederatedPointerEvent);
+
+			expect(callback).toHaveBeenCalledWith("up");
+		});
+	});
+
+	describe("キャンセルコールバック", () => {
+		it("キャンセルボタンクリックでコールバックが呼ばれる", () => {
+			const selector = new DirectionSelector();
+			const callback = vi.fn();
+			selector.setOnCancel(callback);
+			selector.show();
+
+			// 最後のボタン（キャンセル）をクリック
+			const cancelButton = selector.getContainer().children[4];
+			cancelButton.emit("pointerdown", {
+				button: 0,
+			} as FederatedPointerEvent);
+
+			expect(callback).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("ホバーエフェクト", () => {
+		it("方向ボタンにpointeroverリスナーが登録されている", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+
+			const upButton = selector.getContainer().children[0];
+			expect(upButton.listenerCount("pointerover")).toBeGreaterThan(0);
+		});
+
+		it("方向ボタンにpointeroutリスナーが登録されている", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+
+			const upButton = selector.getContainer().children[0];
+			expect(upButton.listenerCount("pointerout")).toBeGreaterThan(0);
+		});
+
+		it("キャンセルボタンにもホバーリスナーが登録されている", () => {
+			const selector = new DirectionSelector();
+			selector.show();
+
+			const cancelButton = selector.getContainer().children[4];
+			expect(cancelButton.listenerCount("pointerover")).toBeGreaterThan(0);
+			expect(cancelButton.listenerCount("pointerout")).toBeGreaterThan(0);
+		});
+	});
+});

--- a/src/ui/directionSelector.ts
+++ b/src/ui/directionSelector.ts
@@ -5,23 +5,25 @@
 
 import { Container, Graphics, Text } from "pixi.js";
 import type { Direction } from "../types";
+import { Easing, tween } from "../utils/tween";
 import { drawRoundedRect, makeInteractive } from "./graphicsHelpers";
+import { HOVER_EFFECT } from "./titleAnimation";
 
 /** ボタンサイズ */
-const BUTTON_SIZE = 56;
-const BUTTON_GAP = 8;
-const BUTTON_RADIUS = 8;
+const BUTTON_SIZE = 64;
+const BUTTON_GAP = 10;
+const BUTTON_RADIUS = 12;
 
 /** 方向ボタン色 */
 const DIRECTION_COLORS = {
-	bg: 0x2a5a3a,
-	border: 0x4a8a5a,
+	bg: 0x2e6640,
+	border: 0x5aaa6a,
 } as const;
 
 /** キャンセルボタン色 */
 const CANCEL_COLORS = {
-	bg: 0x5a3a3a,
-	border: 0x8a5a5a,
+	bg: 0x663030,
+	border: 0xaa5a5a,
 } as const;
 
 /** 方向ボタン定義 */
@@ -140,14 +142,14 @@ export class DirectionSelector {
 		const bg = new Graphics();
 		drawRoundedRect(bg, BUTTON_SIZE, BUTTON_SIZE, BUTTON_RADIUS, colors.bg, {
 			color: colors.border,
-			width: 2,
+			width: 2.5,
 		});
 		button.addChild(bg);
 
 		const text = new Text({
 			text: label,
 			style: {
-				fontSize: 20,
+				fontSize: 24,
 				fontFamily: "sans-serif",
 				fill: 0xffffff,
 				fontWeight: "bold",
@@ -159,7 +161,47 @@ export class DirectionSelector {
 		button.addChild(text);
 
 		makeInteractive(button, onClick);
+		this.addHoverEffect(button);
 
 		return button;
+	}
+
+	/**
+	 * ボタンにホバー演出を追加
+	 */
+	private addHoverEffect(button: Container): void {
+		button.pivot.set(BUTTON_SIZE / 2, BUTTON_SIZE / 2);
+		button.x += BUTTON_SIZE / 2;
+		button.y += BUTTON_SIZE / 2;
+
+		let hoverAbort: AbortController | null = null;
+
+		button.on("pointerover", () => {
+			hoverAbort?.abort();
+			hoverAbort = new AbortController();
+			tween(
+				button,
+				{ scaleX: HOVER_EFFECT.scale, scaleY: HOVER_EFFECT.scale },
+				{
+					duration: HOVER_EFFECT.duration,
+					easing: Easing.easeOut,
+					signal: hoverAbort.signal,
+				},
+			);
+		});
+
+		button.on("pointerout", () => {
+			hoverAbort?.abort();
+			hoverAbort = new AbortController();
+			tween(
+				button,
+				{ scaleX: 1, scaleY: 1 },
+				{
+					duration: HOVER_EFFECT.duration,
+					easing: Easing.easeOut,
+					signal: hoverAbort.signal,
+				},
+			);
+		});
 	}
 }


### PR DESCRIPTION
## 概要
- ボタンサイズを56px→64pxに拡大し、押しやすさを向上
- ボタンの角丸を8px→12pxに拡大し、より丸みのあるデザインに
- ボタン間隔を8px→10pxに広げ、視認性を向上
- 方向ボタン・キャンセルボタンの色を明度アップで視認性改善
- ボーダー幅を2px→2.5pxに太くして輪郭を強調
- 矢印フォントサイズを20→24に拡大
- titleScreenと同じスケールアニメーション（1.08倍, 150ms）によるホバーエフェクトを追加
- DirectionSelectorのユニットテストを新規追加（11テスト）

Closes #314

## テスト計画
- [x] ユニットテスト全通過（821テスト）
- [x] E2Eテスト通過
- [x] TypeScriptビルド成功
- [x] Biome lint/format通過
- [ ] ブラウザで方向選択UIを表示し、ホバーエフェクトを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)