### PR TITLE
feat: makeInteractiveにホバー時の透明度変化エフェクトを追加

### DIFF
--- a/src/ui/graphicsHelpers.test.ts
+++ b/src/ui/graphicsHelpers.test.ts
@@ -256,7 +256,7 @@ describe("makeInteractive", () => {
 		expect(container.alpha).toBe(1);
 	});
 
-	it("ホバー中にalphaが外部変更された場合でもpointeroutでホバー前の値に復元する", () => {
+	it("ホバー中にalphaが外部変更された場合、pointeroutで復元しない", () => {
 		const container = createMockContainer();
 
 		makeInteractive(container, vi.fn());
@@ -272,8 +272,8 @@ describe("makeInteractive", () => {
 		container.alpha = 1.0;
 		pointerout?.();
 
-		// isHoveringフラグによりホバー前の値に復元される
-		expect(container.alpha).toBe(1);
+		// 外部変更後の値が維持される（ホバー前の値に巻き戻さない）
+		expect(container.alpha).toBe(1.0);
 	});
 
 	it("pointeroverが複数回発火してもpointeroutで元のalphaに戻る", () => {

--- a/src/ui/graphicsHelpers.ts
+++ b/src/ui/graphicsHelpers.ts
@@ -58,16 +58,23 @@ export function makeInteractive(
 		onClick(event);
 	});
 	let alphaBeforeHover = target.alpha;
+	let hoverAlpha: number | null = null;
 	let isHovering = false;
 	target.on("pointerover", () => {
 		if (isHovering) return;
 		isHovering = true;
 		alphaBeforeHover = target.alpha;
-		target.alpha = Math.min(HOVER_ALPHA, alphaBeforeHover);
+		const nextAlpha = Math.min(HOVER_ALPHA, alphaBeforeHover);
+		target.alpha = nextAlpha;
+		hoverAlpha = nextAlpha;
 	});
 	target.on("pointerout", () => {
 		if (!isHovering) return;
-		target.alpha = alphaBeforeHover;
+		// ホバーで設定した alpha がまだ維持されている場合のみ復元する
+		if (hoverAlpha !== null && target.alpha === hoverAlpha) {
+			target.alpha = alphaBeforeHover;
+		}
 		isHovering = false;
+		hoverAlpha = null;
 	});
 }


### PR DESCRIPTION
## 概要

- `makeInteractive`関数に`pointerover`/`pointerout`リスナーを追加し、ホバー時にalpha（透明度）を0.8に変化させるエフェクトを実装
- 全16箇所の`makeInteractive`利用箇所で自動的にホバーエフェクトが有効になる
- 既存のカスタムホバーエフェクト（titleScreen/directionSelectorのスケール、handRendererのY移動+ボーダー色）とも自然に共存

Closes #316

## テスト計画

- [x] `pointerover`/`pointerout`リスナーの登録テスト
- [x] ホバー時にalphaが0.8になるテスト
- [x] ホバー解除時にalphaが1に戻るテスト
- [x] 全845テスト通過
- [x] Biome lint/format チェック通過
- [x] TypeScriptビルド通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)