### PR TITLE
fix: ステータスバーがマップの前面に描画されるよう修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,6 @@ async function initializeUIComponents(
 	app.stage.addChild(gameOverScreen.getContainer());
 
 	const statusBar = new StatusBar();
-	app.stage.addChild(statusBar.getContainer());
 
 	// ビューポートラッパー: マップをタイル領域にクリッピング
 	const mapViewport = new Container();
@@ -74,6 +73,9 @@ async function initializeUIComponents(
 	const mapContainer = mapRenderer.getContainer();
 	mapViewport.addChild(mapContainer);
 	app.stage.addChild(mapViewport);
+
+	// statusBarはmapViewportの後に追加（前面に描画するため）
+	app.stage.addChild(statusBar.getContainer());
 
 	// パーティクルはマスクなし（勝利画面の紙吹雪は全画面表示）
 	const particleSystem = new ParticleSystem();


### PR DESCRIPTION
## 概要
- PixiJSの`addChild`順序を修正し、ステータスバー（HP/AP表示）がマップより前面に描画されるようにした
- `main.ts`で`statusBar`の`addChild`を`mapViewport`の後に移動

Closes #327

## テスト計画
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全841テスト通過
- [x] `pnpm test:e2e` — E2Eテスト通過
- [ ] 目視確認: HP/APの表示がマップに隠れず常に視認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)