### PR TITLE
refactor: tileEffect.tsの冗長なゲームオーバー判定を簡素化

### DIFF
--- a/src/game/tileEffect.ts
+++ b/src/game/tileEffect.ts
@@ -45,11 +45,12 @@ export function applyTileEffect(state: GameState): TileEffectResult {
 		case "trap": {
 			next = applyDamageToPlayer(next, TRAP_DAMAGE);
 			next = addActionLog(next, "罠を踏んだ！", "player");
-			const gameOver = isDefeated(next.player.hp);
-			if (gameOver) {
-				next = checkGameOver(next);
-			}
-			return { state: next, triggeredTile: "trap", gameOver };
+			next = checkGameOver(next);
+			return {
+				state: next,
+				triggeredTile: "trap",
+				gameOver: isDefeated(next.player.hp),
+			};
 		}
 		case "treasure": {
 			const healed = Math.min(


### PR DESCRIPTION
## 概要
- `tileEffect.ts` の罠処理で冗長な `isDefeated()` 事前チェックを削除
- `checkGameOver()` を常に呼び出すように変更（内部で `isDefeated` チェック済みのため安全）
- `gameOver` 戻り値は `isDefeated(next.player.hp)` で決定する形に統一

Closes #346

## テスト計画
- [x] `pnpm format` — フォーマットエラーなし
- [x] `pnpm lint` — 新規の警告・エラーなし
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全952テストパス（55ファイル）
- [x] `pnpm test:e2e` — e2eテストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)