### PR TITLE
refactor: positionUtils関数の不要な再エクスポートと重複テスト削除

### DIFF
--- a/src/game/enemyAi.test.ts
+++ b/src/game/enemyAi.test.ts
@@ -13,57 +13,8 @@ import {
 } from "../test-utils/createTestFixtures";
 import type { Enemy } from "../types";
 import { RNG } from "../utils/rng";
-import {
-	executeEnemyTurn,
-	isAdjacent,
-	manhattanDistance,
-	pickMoveDirection,
-} from "./enemyAi";
+import { executeEnemyTurn, pickMoveDirection } from "./enemyAi";
 import { createFixedLayoutMap } from "./map";
-
-describe("isAdjacent", () => {
-	it("上方向に隣接している場合trueを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 3, y: 2 })).toBe(true);
-	});
-
-	it("下方向に隣接している場合trueを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 3, y: 4 })).toBe(true);
-	});
-
-	it("左方向に隣接している場合trueを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 2, y: 3 })).toBe(true);
-	});
-
-	it("右方向に隣接している場合trueを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 4, y: 3 })).toBe(true);
-	});
-
-	it("斜め方向は隣接していないのでfalseを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 4, y: 4 })).toBe(false);
-	});
-
-	it("同じ位置は隣接していないのでfalseを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 3, y: 3 })).toBe(false);
-	});
-
-	it("2マス以上離れている場合falseを返す", () => {
-		expect(isAdjacent({ x: 3, y: 3 }, { x: 5, y: 3 })).toBe(false);
-	});
-});
-
-describe("manhattanDistance", () => {
-	it("同じ位置の距離は0", () => {
-		expect(manhattanDistance({ x: 3, y: 3 }, { x: 3, y: 3 })).toBe(0);
-	});
-
-	it("隣接する位置の距離は1", () => {
-		expect(manhattanDistance({ x: 3, y: 3 }, { x: 4, y: 3 })).toBe(1);
-	});
-
-	it("離れた位置の距離を正しく計算する", () => {
-		expect(manhattanDistance({ x: 1, y: 1 }, { x: 5, y: 4 })).toBe(7);
-	});
-});
 
 describe("pickMoveDirection", () => {
 	it("プレイヤーが上にいる場合、上方向を返す", () => {

--- a/src/game/enemyAi.ts
+++ b/src/game/enemyAi.ts
@@ -19,8 +19,6 @@ import { isAdjacent, manhattanDistance } from "./positionUtils";
 import { findRoomAt, isInRoom } from "./roomUtils";
 import { addActionLog, setEnemies, updateEnemy } from "./state";
 
-export { isAdjacent, manhattanDistance };
-
 /**
  * 敵の移動可否を判定
  *


### PR DESCRIPTION
## 概要
- `enemyAi.ts` から `isAdjacent` / `manhattanDistance` の再エクスポート（`export { isAdjacent, manhattanDistance }`）を削除
- `enemyAi.test.ts` から `positionUtils.test.ts` と完全に重複していた `isAdjacent` / `manhattanDistance` のテスト（10テストケース）を削除
- `enemyAi.test.ts` のimport文から不要になった `isAdjacent` / `manhattanDistance` を除去

Closes #344

## テスト計画
- [x] `pnpm format` — フォーマットエラーなし
- [x] `pnpm lint` — 新規のlintエラーなし
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全942テストパス
- [x] `pnpm test:e2e` — e2eテストパス
- [x] `positionUtils.test.ts` のテストが引き続き全件パスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)