### PR TITLE
refactor: AP消費・カード使用の共通ヘルパー抽出

### DIFF
--- a/src/game/action.test.ts
+++ b/src/game/action.test.ts
@@ -15,12 +15,75 @@ import {
 } from "../test-utils/createTestFixtures";
 import type { Enemy } from "../types";
 import {
+	consumeApAndPlayCard,
 	executeAttack,
 	executeJump,
 	executeMove,
 	executeStrongAttack,
 	executeWait,
 } from "./action";
+
+describe("consumeApAndPlayCard", () => {
+	it("APが指定コスト分減少する", () => {
+		const state = createTestState({
+			deck: {
+				drawPile: [],
+				hand: [{ id: "move-1", type: "move" }],
+				discardPile: [],
+			},
+		});
+		const result = consumeApAndPlayCard(state, "move-1", CARD_COST.move);
+
+		expect(result.player.ap).toBe(MAX_AP - CARD_COST.move);
+	});
+
+	it("カードが手札から捨て札に移動する", () => {
+		const state = createTestState({
+			deck: {
+				drawPile: [],
+				hand: [{ id: "attack-1", type: "attack" }],
+				discardPile: [],
+			},
+		});
+		const result = consumeApAndPlayCard(state, "attack-1", CARD_COST.attack);
+
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+		expect(result.deck.discardPile[0].id).toBe("attack-1");
+	});
+
+	it("コスト0の場合APが変化しない", () => {
+		const state = createTestState({
+			deck: {
+				drawPile: [],
+				hand: [{ id: "wait-1", type: "wait" }],
+				discardPile: [],
+			},
+		});
+		const result = consumeApAndPlayCard(state, "wait-1", CARD_COST.wait);
+
+		expect(result.player.ap).toBe(MAX_AP);
+		expect(result.deck.hand).toHaveLength(0);
+		expect(result.deck.discardPile).toHaveLength(1);
+	});
+
+	it("元のGameStateが変更されない（イミュータブル）", () => {
+		const state = createTestState({
+			deck: {
+				drawPile: [],
+				hand: [{ id: "move-1", type: "move" }],
+				discardPile: [],
+			},
+		});
+		const originalAp = state.player.ap;
+
+		consumeApAndPlayCard(state, "move-1", CARD_COST.move);
+
+		expect(state.player.ap).toBe(originalAp);
+		expect(state.deck.hand).toHaveLength(1);
+		expect(state.deck.discardPile).toHaveLength(0);
+	});
+});
 
 describe("executeMove", () => {
 	it("床タイルへの移動成功: 位置更新・AP消費・カード捨て札移動・行動ログ", () => {

--- a/src/game/action.ts
+++ b/src/game/action.ts
@@ -19,6 +19,22 @@ import { addActionLog, setDeck, setVisitedTiles, updatePlayer } from "./state";
 import { applyTileEffect } from "./tileEffect";
 
 /**
+ * AP消費 + カードを捨て札へ移動する共通ヘルパー
+ */
+export function consumeApAndPlayCard(
+	state: GameState,
+	cardId: string,
+	apCost: number,
+): GameState {
+	let next = updatePlayer(state, (p) => ({
+		...p,
+		ap: p.ap - apCost,
+	}));
+	next = setDeck(next, playCard(next.deck, cardId));
+	return next;
+}
+
+/**
  * 移動可否を判定
  */
 function canMove(state: GameState, direction: Direction): boolean {
@@ -67,14 +83,8 @@ export function executeMove(
 	cardId: string,
 	direction: Direction,
 ): MoveResult {
-	// AP消費
-	let next = updatePlayer(state, (p) => ({
-		...p,
-		ap: p.ap - CARD_COST.move,
-	}));
-
-	// カードを捨て札へ
-	next = setDeck(next, playCard(next.deck, cardId));
+	// AP消費 + カードを捨て札へ
+	let next = consumeApAndPlayCard(state, cardId, CARD_COST.move);
 
 	// 移動判定
 	if (!canMove(state, direction)) {
@@ -182,14 +192,8 @@ function executeAttackBase(
 	damage: number,
 	missLog: string,
 ): AttackResult {
-	// AP消費
-	let next = updatePlayer(state, (p) => ({
-		...p,
-		ap: p.ap - apCost,
-	}));
-
-	// カードを捨て札へ
-	next = setDeck(next, playCard(next.deck, cardId));
+	// AP消費 + カードを捨て札へ
+	let next = consumeApAndPlayCard(state, cardId, apCost);
 
 	// 攻撃判定（AP消費・カード使用後の状態で判定）
 	const result = canAttack(next, direction);
@@ -277,14 +281,8 @@ export function executeJump(
 ): JumpResult {
 	const delta = DIRECTION_DELTA[direction];
 
-	// AP消費
-	let next = updatePlayer(state, (p) => ({
-		...p,
-		ap: p.ap - CARD_COST.jump,
-	}));
-
-	// カードを捨て札へ
-	next = setDeck(next, playCard(next.deck, cardId));
+	// AP消費 + カードを捨て札へ
+	let next = consumeApAndPlayCard(state, cardId, CARD_COST.jump);
 
 	// 着地先（2マス先）の座標を計算
 	const landX = next.player.position.x + delta.x * JUMP_DISTANCE;
@@ -388,14 +386,8 @@ export function executeJump(
  * APコスト0。カードを捨て札へ移動し、行動ログを記録する。
  */
 export function executeWait(state: GameState, cardId: string): GameState {
-	// AP消費（コスト0）
-	let next = updatePlayer(state, (p) => ({
-		...p,
-		ap: p.ap - CARD_COST.wait,
-	}));
-
-	// カードを捨て札へ
-	next = setDeck(next, playCard(next.deck, cardId));
+	// AP消費 + カードを捨て札へ
+	const next = consumeApAndPlayCard(state, cardId, CARD_COST.wait);
 
 	return addActionLog(next, "待機した", "player");
 }


### PR DESCRIPTION
## 概要
- `consumeApAndPlayCard` ヘルパー関数を `action.ts` に追加し、AP消費+カード捨て札移動の共通処理を集約
- `executeMove`, `executeAttackBase`, `executeJump`, `executeWait` の4箇所をヘルパー呼び出しに置き換え
- ヘルパー関数の直接テスト（AP消費・カード移動・コスト0・イミュータブル性）を追加

Closes #345

## テスト計画
- [x] `consumeApAndPlayCard` の単体テスト（4ケース）がパス
- [x] 既存の `executeMove` / `executeAttack` / `executeStrongAttack` / `executeJump` / `executeWait` テスト（全956テスト）がパス
- [x] `pnpm lint` / `pnpm build` / `pnpm test:e2e` が正常完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)