### PR TITLE
fix: パーティクルエフェクトの座標変換を修正

### DIFF
--- a/src/ui/coordinates.test.ts
+++ b/src/ui/coordinates.test.ts
@@ -12,6 +12,7 @@ import {
 	getMapPixelSize,
 	getViewportPixelSize,
 	gridToCenterPixel,
+	gridToParticlePosition,
 	gridToPixel,
 	pixelToGrid,
 } from "./coordinates";
@@ -298,6 +299,84 @@ describe("calculateCameraOffset（ズーム対応）", () => {
 		const centered = (viewportPx - scaledMapPx) / 2;
 		const result = calculateCameraOffset({ x: 5, y: 5 }, 11, 11, 0.5);
 		expect(result).toEqual({ x: centered, y: centered });
+	});
+});
+
+describe("gridToParticlePosition", () => {
+	it("マップ空間の座標をパーティクルコンテナ空間に変換する", () => {
+		// mapContainerがオフセット(100, 50)を持つ場合
+		const mapContainer = {
+			toGlobal: (pos: { x: number; y: number }) => ({
+				x: pos.x + 100,
+				y: pos.y + 50,
+			}),
+			toLocal: (pos: { x: number; y: number }) => pos,
+		};
+		// particleContainerがオフセット(20, 30)を持つ場合
+		const particleContainer = {
+			toGlobal: (pos: { x: number; y: number }) => pos,
+			toLocal: (pos: { x: number; y: number }) => ({
+				x: pos.x - 20,
+				y: pos.y - 30,
+			}),
+		};
+
+		const result = gridToParticlePosition(
+			{ x: 0, y: 0 },
+			mapContainer,
+			particleContainer,
+		);
+
+		// gridToCenterPixel({x:0,y:0}) → {x: CELL_GAP + CELL_SIZE/2, y: CELL_GAP + CELL_SIZE/2}
+		const expectedMapCenter = gridToCenterPixel({ x: 0, y: 0 });
+		// toGlobal: + (100, 50)
+		const expectedGlobal = {
+			x: expectedMapCenter.x + 100,
+			y: expectedMapCenter.y + 50,
+		};
+		// toLocal: - (20, 30)
+		expect(result).toEqual({
+			x: expectedGlobal.x - 20,
+			y: expectedGlobal.y - 30,
+		});
+	});
+
+	it("変換なし（単位変換）の場合はgridToCenterPixelと同じ結果を返す", () => {
+		const identity = {
+			toGlobal: (pos: { x: number; y: number }) => ({ ...pos }),
+			toLocal: (pos: { x: number; y: number }) => ({ ...pos }),
+		};
+
+		const result = gridToParticlePosition({ x: 3, y: 5 }, identity, identity);
+		expect(result).toEqual(gridToCenterPixel({ x: 3, y: 5 }));
+	});
+
+	it("ズーム適用時の座標変換が正しく行われる", () => {
+		// mapContainerが2倍ズームのスケール
+		const mapContainer = {
+			toGlobal: (pos: { x: number; y: number }) => ({
+				x: pos.x * 2,
+				y: pos.y * 2,
+			}),
+			toLocal: (pos: { x: number; y: number }) => pos,
+		};
+		const particleContainer = {
+			toGlobal: (pos: { x: number; y: number }) => pos,
+			toLocal: (pos: { x: number; y: number }) => ({ ...pos }),
+		};
+
+		const gridPos = { x: 2, y: 3 };
+		const result = gridToParticlePosition(
+			gridPos,
+			mapContainer,
+			particleContainer,
+		);
+
+		const mapCenter = gridToCenterPixel(gridPos);
+		expect(result).toEqual({
+			x: mapCenter.x * 2,
+			y: mapCenter.y * 2,
+		});
 	});
 });
 

--- a/src/ui/coordinates.ts
+++ b/src/ui/coordinates.ts
@@ -8,6 +8,31 @@ import type { Position } from "../types";
 
 const CELL_WITH_GAP = CELL_SIZE + CELL_GAP;
 
+/** toGlobal/toLocalを持つコンテナのインタフェース */
+interface SpatialContainer {
+	toGlobal(pos: { x: number; y: number }): { x: number; y: number };
+	toLocal(pos: { x: number; y: number }): { x: number; y: number };
+}
+
+/**
+ * グリッド座標をパーティクルコンテナ空間の座標に変換
+ * マップ空間 → グローバル空間 → パーティクル空間 の変換パイプライン
+ * @param gridPos グリッド座標
+ * @param mapContainer マップのPixiJSコンテナ
+ * @param particleContainer パーティクルのPixiJSコンテナ
+ * @returns パーティクルコンテナ空間の座標
+ */
+export function gridToParticlePosition(
+	gridPos: Position,
+	mapContainer: SpatialContainer,
+	particleContainer: SpatialContainer,
+): Position {
+	const mapCenter = gridToCenterPixel(gridPos);
+	const globalCenter = mapContainer.toGlobal(mapCenter);
+	const local = particleContainer.toLocal(globalCenter);
+	return { x: local.x, y: local.y };
+}
+
 /**
  * グリッド座標からピクセル座標（左上）を計算
  * @param gridPos グリッド座標（0-indexed）

--- a/src/ui/eventHandlers.ts
+++ b/src/ui/eventHandlers.ts
@@ -39,7 +39,7 @@ import {
 	calculateCameraOffset,
 	clampCameraOffset,
 	getViewportPixelSize,
-	gridToCenterPixel,
+	gridToParticlePosition,
 } from "./coordinates";
 import { detectEnemyMoves } from "./enemyMoveDetector";
 import {
@@ -84,11 +84,11 @@ async function showTileEffectPopup(
 
 	if (amount <= 0) return;
 
-	const mapCenter = gridToCenterPixel(gridPos);
-	const globalCenter = ctx.ui.mapRenderer.getContainer().toGlobal(mapCenter);
-	const particleOrigin = ctx.ui.particleSystem
-		.getContainer()
-		.toLocal(globalCenter);
+	const particleOrigin = gridToParticlePosition(
+		gridPos,
+		ctx.ui.mapRenderer.getContainer(),
+		ctx.ui.particleSystem.getContainer(),
+	);
 	const particleConfig =
 		tileType === "trap"
 			? createTrapDamageParticleConfig(particleOrigin)
@@ -227,7 +227,11 @@ function emitJumpParticles(
 	originPos: Position,
 	moveAngle: number,
 ): void {
-	const center = gridToCenterPixel(originPos);
+	const center = gridToParticlePosition(
+		originPos,
+		ctx.ui.mapRenderer.getContainer(),
+		ctx.ui.particleSystem.getContainer(),
+	);
 	ctx.ui.particleSystem.emit(createJumpParticleConfig(center, moveAngle));
 }
 

--- a/src/ui/gameAnimations.ts
+++ b/src/ui/gameAnimations.ts
@@ -17,7 +17,7 @@ import {
 	createDefeatParticleConfig,
 	getAttackParticleConfig,
 } from "./battleParticles";
-import { getViewportPixelSize, gridToCenterPixel } from "./coordinates";
+import { getViewportPixelSize, gridToParticlePosition } from "./coordinates";
 import { applyState, render } from "./gameRenderer";
 import { HAND_AREA_HEIGHT } from "./layout";
 
@@ -209,7 +209,11 @@ export async function updateStateWithAttackAnimation(
 
 		// カードタイプ別パーティクル
 		if (hitEnemy) {
-			const center = gridToCenterPixel(hitEnemy.position);
+			const center = gridToParticlePosition(
+				hitEnemy.position,
+				ctx.ui.mapRenderer.getContainer(),
+				ctx.ui.particleSystem.getContainer(),
+			);
 			hitAnimations.push(
 				ctx.ui.particleSystem.emit(getAttackParticleConfig(cardType, center)),
 			);
@@ -223,7 +227,11 @@ export async function updateStateWithAttackAnimation(
 				ctx.ui.mapRenderer.animateEnemyDefeat(hitEnemyId),
 			];
 			if (hitEnemy) {
-				const center = gridToCenterPixel(hitEnemy.position);
+				const center = gridToParticlePosition(
+					hitEnemy.position,
+					ctx.ui.mapRenderer.getContainer(),
+					ctx.ui.particleSystem.getContainer(),
+				);
 				defeatAnimations.push(
 					ctx.ui.particleSystem.emit(createDefeatParticleConfig(center)),
 				);


### PR DESCRIPTION
## 概要
- `gridToParticlePosition` ヘルパー関数を `coordinates.ts` に追加し、マップ空間→グローバル空間→パーティクル空間の座標変換パイプラインを共通化
- `gameAnimations.ts` の攻撃パーティクル・撃破パーティクルの座標計算を修正
- `eventHandlers.ts` のジャンプパーティクルの座標計算を修正
- `showTileEffectPopup` のインライン座標変換も共通ヘルパーに統一

Closes #388

## テスト計画
- [x] `gridToParticlePosition` のユニットテスト追加（3ケース）
- [x] 既存の全テスト（1092件）通過
- [x] TypeScriptビルド成功
- [x] E2Eテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)