### PR TITLE
chore: フォーク固有のコマンド修正とリポジトリ名を修正

### DIFF
--- a/.claude/commands/issue-pr.md
+++ b/.claude/commands/issue-pr.md
@@ -2,18 +2,10 @@
 
 ## コンテキスト
 
-### 対象リポジトリ（origin）
-
-```
-$![git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||']
-```
-
-> **重要**: フォーク構成のリポジトリでは `gh` がフォーク元を参照するため、以降の `gh issue` / `gh pr` コマンドには必ず `--repo {owner}/{repo}` を付与すること。以降のコマンドで `{owner}/{repo}` と表記している箇所を上記の値で置き換えること。
-
 ### オープンIssue一覧
 
 ```
-$![gh issue list --repo "$(git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')"]
+$![gh issue list]
 ```
 
 ## 指示
@@ -37,7 +29,7 @@ $![gh issue list --repo "$(git remote get-url origin | sed 's|.*github.com[:/]||
 
 ### P-1. 事前準備
 
-1. 各Issueの詳細を `gh issue view <番号> --repo {owner}/{repo}` で取得し、内容を把握する
+1. 各Issueの詳細を `gh issue view <番号>` で取得し、内容を把握する
 2. 対応方針の一覧をユーザーに提示し、承認を得る
 
 ### P-2. チームの作成
@@ -113,7 +105,7 @@ git worktree add /tmp/wt-issue-<番号> <ブランチ名>
 5. **push**: `git -C /tmp/wt-issue-<番号> push -u origin <ブランチ名>`
 6. **PR作成**（worktreeディレクトリで実行すること）:
    ```
-   cd /tmp/wt-issue-<番号> && gh pr create --repo {owner}/{repo} --base main --head <ブランチ名> --title "<type>: <日本語の説明>" --body "$(cat <<'EOF'
+   cd /tmp/wt-issue-<番号> && gh pr create --base main --head <ブランチ名> --title "<type>: <日本語の説明>" --body "$(cat <<'EOF'
    ## 概要
    <変更内容の箇条書き>
 
@@ -159,7 +151,7 @@ git worktree add /tmp/wt-issue-<番号> <ブランチ名>
 
 ### 2. Issue詳細の取得
 
-`gh issue view <番号> --repo {owner}/{repo}` を実行し、Issueの内容を把握してください。
+`gh issue view <番号>` を実行し、Issueの内容を把握してください。
 
 ### 3. ブランチの作成
 
@@ -212,7 +204,7 @@ Issue の内容に従い、TDD（テスト駆動開発）で実装を行って�
 以下の形式でPRを作成してください:
 
 ```
-gh pr create --repo {owner}/{repo} --base main --title "<type>: <日本語の説明>" --body "$(cat <<'EOF'
+gh pr create --base main --title "<type>: <日本語の説明>" --body "$(cat <<'EOF'
 ## 概要
 <変更内容の箇条書き>
 

--- a/.claude/commands/refactor-issues.md
+++ b/.claude/commands/refactor-issues.md
@@ -2,14 +2,6 @@
 
 ## コンテキスト
 
-### 対象リポジトリ（origin）
-
-```
-$![git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||']
-```
-
-> **重要**: フォーク構成のリポジトリでは `gh` がフォーク元を参照するため、`gh issue create` の `--repo` には必ず上記のリポジトリを指定すること。以降のコマンドで `{owner}/{repo}` と表記している箇所を上記の値で置き換えること。
-
 ### 調査対象
 
 - 引数: `$ARGUMENTS`
@@ -59,7 +51,6 @@ Issue間の依存関係を分析し、**番号が若い順にPR作成すれば�
 
 ```
 gh issue create \
-  --repo {owner}/{repo} \
   --title "refactor: <日本語の簡潔な説明>" \
   --body "$(cat <<'EOF'
 ## 背景

--- a/.claude/commands/resolve-pr-review.md
+++ b/.claude/commands/resolve-pr-review.md
@@ -7,14 +7,6 @@
 - 引数にPR番号が指定されていればそのPRを対象とする（スペース区切りで複数指定可能）
 - 引数が空の場合は、現在のブランチに紐づく最新のPRを対象とする
 
-### 対象リポジトリ（origin）
-
-```
-$![git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||']
-```
-
-> **重要**: フォーク構成のリポジトリでは `gh` がフォーク元を参照するため、以降の `gh pr` コマンドにも必ず `--repo {owner}/{repo}` を付与すること。以降のコマンドで `{owner}/{repo}` と表記している箇所を上記の値で置き換えること。GraphQL APIの `owner` `repo` にはそれぞれ `/` で分割した値を使用すること。
-
 ## 指示
 
 以下の手順でPRのレビューコメントを確認・解決し、pushまで行ってください。
@@ -52,13 +44,13 @@ TeamCreateでチームを作成する:
 
 ```bash
 # PRをドラフトに変換
-gh pr ready --repo {owner}/{repo} --undo <番号>
+gh pr ready --undo <番号>
 
 # worktreeを作成（/tmp配下に作成し、メインリポジトリを汚さない）
 git worktree add /tmp/wt-pr-<番号>
 
 # worktree側でPRブランチをcheckoutし、依存関係をインストール
-(cd /tmp/wt-pr-<番号> && gh pr checkout --repo {owner}/{repo} <番号> && pnpm install)
+(cd /tmp/wt-pr-<番号> && gh pr checkout <番号> && pnpm install)
 ```
 
 ### P-5. エージェントの並列起動
@@ -143,7 +135,7 @@ git worktree add /tmp/wt-pr-<番号>
 
 6. **ドラフトを解除**:
    ```
-   cd /tmp/wt-pr-<番号> && gh pr ready --repo {owner}/{repo} <番号>
+   cd /tmp/wt-pr-<番号> && gh pr ready <番号>
    ```
 
 完了したら、対応したコメント数とPRのURLを報告してください。
@@ -154,7 +146,7 @@ git worktree add /tmp/wt-pr-<番号>
 全エージェントの完了を待ち、以下を行う:
 
 1. 各エージェントの結果（対応コメント数、PRのURL等）をまとめてユーザーに報告する
-2. 各PRのドラフトが解除されているか確認し、ドラフトのまま残っている場合は `gh pr ready --repo {owner}/{repo} <番号>` で解除する
+2. 各PRのドラフトが解除されているか確認し、ドラフトのまま残っている場合は `gh pr ready <番号>` で解除する
 3. git worktreeを削除する:
    ```bash
    git worktree remove /tmp/wt-pr-<番号>
@@ -170,7 +162,7 @@ git worktree add /tmp/wt-pr-<番号>
 引数が空の場合は、現在のブランチに紐づくPR番号を取得する:
 
 ```
-gh pr view --repo {owner}/{repo} --json number -q .number
+gh pr view --json number -q .number
 ```
 
 [未解決スレッドの取得](#ref-未解決のレビュースレッドを取得) の手順でレビュースレッドを取得し、必要に応じて [コメントの詳細を取得](#ref-コメントの詳細を取得) で全文を取得する。
@@ -198,8 +190,8 @@ gh pr view --repo {owner}/{repo} --json number -q .number
 ### 4. PRをドラフトに変換・ブランチ切り替え
 
 ```
-gh pr ready --repo {owner}/{repo} --undo <番号>
-gh pr checkout --repo {owner}/{repo} <番号>
+gh pr ready --undo <番号>
+gh pr checkout <番号>
 ```
 
 ### 5. 実装・コミット・push（1コメントずつ）
@@ -275,7 +267,7 @@ gh api repos/{owner}/{repo}/pulls/<番号>/requested_reviewers \
 ### 7. PRをOPENに戻す
 
 ```
-gh pr ready --repo {owner}/{repo} <番号>
+gh pr ready <番号>
 ```
 
 これにより、CIが `ready_for_review` イベントで起動する。

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,15 +1,5 @@
 # 現在の作業をcommit・push・PR作成
 
-## コンテキスト
-
-### 対象リポジトリ（origin）
-
-```
-$![git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||']
-```
-
-> **重要**: フォーク構成のリポジトリでは `gh` がフォーク元を参照するため、以降の `gh pr` コマンドには必ず `--repo {owner}/{repo}` を付与すること。以降のコマンドで `{owner}/{repo}` と表記している箇所を上記の値で置き換えること。
-
 ## 指示
 
 現在のブランチの変更をコミットし、リモートにpushし、PRを作成してください。
@@ -48,12 +38,12 @@ $![git remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||']
 
 ### 5. PR作成
 
-- 既にこのブランチのPRが存在するか `gh pr list --repo {owner}/{repo} --head <ブランチ名>` で確認
+- 既にこのブランチのPRが存在するか `gh pr list --head <ブランチ名>` で確認
 - PRが既に存在する場合はpushのみで完了（PRのURLを表示する）
 - PRが存在しない場合は以下の形式で新規作成:
 
 ```
-gh pr create --repo {owner}/{repo} --base main --title "<type>: <日本語の説明>" --body "$(cat <<'EOF'
+gh pr create --base main --title "<type>: <日本語の説明>" --body "$(cat <<'EOF'
 ## 概要
 <mainからの全変更内容を分析した箇条書き>
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.event.action != 'closed'
         run: pnpm build
         env:
-          BASE_PATH: /game-001-dungeon-cards-02/pr-preview/pr-${{ github.event.number }}/
+          BASE_PATH: /game-001-dungeon-cards/pr-preview/pr-${{ github.event.number }}/
 
       - uses: rossjrw/pr-preview-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# game-001-dungeon-cards-02
+# game-001-dungeon-cards
 
 タイル制ローグライク × デッキ構築カードゲーム
 

--- a/src/game/cardQueue.ts
+++ b/src/game/cardQueue.ts
@@ -1,6 +1,6 @@
 /**
  * カード予約キュー管理
- * @see https://github.com/2rumaki-playground/game-001-dungeon-cards-02/issues/263
+ * @see https://github.com/2rumaki-playground/game-001-dungeon-cards/issues/263
  */
 
 import type { Card, Direction } from "../types";


### PR DESCRIPTION
## 概要
- 4つのカスタムコマンド（`issue-pr.md`, `ship.md`, `resolve-pr-review.md`, `refactor-issues.md`）からフォーク固有のロジックを除去
  - 「対象リポジトリ（origin）」コンテキストセクション
  - フォーク構成に関する「重要」警告文
  - `gh` コマンドの `--repo {owner}/{repo}` フラグ
- `game-001-dungeon-cards-02` への参照を `game-001-dungeon-cards` に修正（`README.md`, `.github/workflows/preview.yml`, `src/game/cardQueue.ts`）

Closes #394

## テスト計画
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全1218テスト合格
- [x] `pnpm test:e2e` — E2Eテスト合格
- [x] `pnpm lint` — リントチェック通過（既存warning19件のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)