### PR TITLE
refactor: カード効果テキストを削除しツールチップに集約

### DIFF
--- a/src/ui/cardConstants.test.ts
+++ b/src/ui/cardConstants.test.ts
@@ -3,7 +3,6 @@ import type { CardType, Rarity } from "../types";
 import {
 	CARD_COLORS,
 	CARD_DESCRIPTION,
-	CARD_EFFECT_TEXT,
 	CARD_GLOW_COLORS,
 	CARD_TYPE_NAME,
 	CARD_TYPE_SYMBOL,
@@ -46,15 +45,6 @@ describe("cardConstants", () => {
 			for (const type of ALL_CARD_TYPES) {
 				expect(typeof CARD_TYPE_NAME[type]).toBe("string");
 				expect(CARD_TYPE_NAME[type].length).toBeGreaterThan(0);
-			}
-		});
-	});
-
-	describe("CARD_EFFECT_TEXT", () => {
-		it("全カード種別に効果テキストが定義されている", () => {
-			for (const type of ALL_CARD_TYPES) {
-				expect(typeof CARD_EFFECT_TEXT[type]).toBe("string");
-				expect(CARD_EFFECT_TEXT[type].length).toBeGreaterThan(0);
 			}
 		});
 	});

--- a/src/ui/cardConstants.ts
+++ b/src/ui/cardConstants.ts
@@ -28,15 +28,6 @@ export const CARD_TYPE_SYMBOL: Record<CardType, string> = {
 	wait: "⏳",
 };
 
-/** カード効果テキスト */
-export const CARD_EFFECT_TEXT: Record<CardType, string> = {
-	move: "1マス移動",
-	attack: `${PLAYER_ATTACK_DAMAGE}ダメージ`,
-	strong_attack: `${PLAYER_STRONG_ATTACK_DAMAGE}ダメージ`,
-	jump: `${JUMP_DISTANCE}マス先に着地`,
-	wait: "-",
-};
-
 /** カード種別の日本語名 */
 export const CARD_TYPE_NAME: Record<CardType, string> = {
 	move: "移動",

--- a/src/ui/cardRowRenderer.test.ts
+++ b/src/ui/cardRowRenderer.test.ts
@@ -1,10 +1,6 @@
 import { Container, Text } from "pixi.js";
 import { describe, expect, it } from "vitest";
-import {
-	CARD_EFFECT_TEXT,
-	CARD_TYPE_NAME,
-	CARD_TYPE_SYMBOL,
-} from "./cardConstants";
+import { CARD_TYPE_NAME, CARD_TYPE_SYMBOL } from "./cardConstants";
 import {
 	CARD_ROW_HEIGHT,
 	CARD_ROW_LIST_WIDTH,
@@ -50,23 +46,19 @@ describe("cardRowRenderer", () => {
 			expect(nameText?.style.fontWeight).toBe("bold");
 		});
 
-		it("効果テキストが含まれる", () => {
+		it("APコストが表示される", () => {
 			const row = createCardListRow({ cardType: "move" });
 			const texts = row.children.filter((c) => c instanceof Text) as Text[];
-			const effectText = texts.find((t) =>
-				t.text.includes(CARD_EFFECT_TEXT.move),
-			);
-			expect(effectText).toBeDefined();
+			const costText = texts.find((t) => t.text.includes("AP:"));
+			expect(costText).toBeDefined();
+			expect(costText?.style.fontSize).toBe(11);
 		});
 
-		it("効果テキストのフォントサイズが11px", () => {
-			const row = createCardListRow({ cardType: "attack" });
+		it("APコスト0のカードはコストテキストが空", () => {
+			const row = createCardListRow({ cardType: "wait" });
 			const texts = row.children.filter((c) => c instanceof Text) as Text[];
-			const effectText = texts.find((t) =>
-				t.text.includes(CARD_EFFECT_TEXT.attack),
-			);
-			expect(effectText).toBeDefined();
-			expect(effectText?.style.fontSize).toBe(11);
+			const costText = texts.find((t) => t.text.includes("AP:"));
+			expect(costText).toBeUndefined();
 		});
 
 		it("枚数を指定すると名前行に枚数が表示される", () => {

--- a/src/ui/cardRowRenderer.ts
+++ b/src/ui/cardRowRenderer.ts
@@ -8,7 +8,6 @@ import { CARD_COST } from "../constants";
 import type { CardType } from "../types";
 import {
 	CARD_COLORS,
-	CARD_EFFECT_TEXT,
 	CARD_RARITY,
 	CARD_TYPE_NAME,
 	CARD_TYPE_SYMBOL,
@@ -55,7 +54,7 @@ type CardListRowOptions = {
 /**
  * カード一覧の1行を生成する共通ヘルパー
  *
- * 背景 + レアリティバー + カード名（シンボル付き） + 効果テキスト を描画する。
+ * 背景 + レアリティバー + カード名（シンボル付き） + APコスト を描画する。
  * 追加のUI要素（除去ボタン等）は呼び出し側でコンテナに追加する。
  */
 export function createCardListRow(options: CardListRowOptions): Container {
@@ -104,14 +103,11 @@ export function createCardListRow(options: CardListRowOptions): Container {
 	nameText.y = NAME_Y;
 	row.addChild(nameText);
 
-	// AP + 効果テキスト
+	// APコスト
 	const cost = CARD_COST[cardType];
-	const effectStr =
-		cost > 0
-			? `${CARD_EFFECT_TEXT[cardType]} / AP: ${cost}`
-			: CARD_EFFECT_TEXT[cardType];
+	const costStr = cost > 0 ? `AP: ${cost}` : "";
 	const effectText = new Text({
-		text: effectStr,
+		text: costStr,
 		style: {
 			fontSize: EFFECT_FONT_SIZE,
 			fontFamily: "sans-serif",

--- a/src/ui/gridCardView.test.ts
+++ b/src/ui/gridCardView.test.ts
@@ -2,12 +2,7 @@ import { Container, Graphics, Text } from "pixi.js";
 import { describe, expect, it } from "vitest";
 import { CARD_COST } from "../constants";
 import type { CardType } from "../types";
-import {
-	CARD_COLORS,
-	CARD_EFFECT_TEXT,
-	CARD_TYPE_NAME,
-	CARD_TYPE_SYMBOL,
-} from "./cardConstants";
+import { CARD_COLORS, CARD_TYPE_NAME, CARD_TYPE_SYMBOL } from "./cardConstants";
 import { createGridCardView } from "./gridCardView";
 import { CARD_HEIGHT, CARD_WIDTH } from "./handRenderer";
 
@@ -37,14 +32,6 @@ describe("gridCardView", () => {
 			const name = texts.find((t) => t.text === CARD_TYPE_NAME.jump);
 			expect(name).toBeDefined();
 			expect(name?.style.fontWeight).toBe("bold");
-		});
-
-		it("効果テキストが含まれる", () => {
-			const view = createGridCardView("move");
-			const texts = view.children.filter((c) => c instanceof Text) as Text[];
-			const effect = texts.find((t) => t.text === CARD_EFFECT_TEXT.move);
-			expect(effect).toBeDefined();
-			expect(effect?.style.fontSize).toBe(11);
 		});
 
 		it("各カードタイプで正しいシンボル・名前が使用される", () => {
@@ -111,9 +98,9 @@ describe("gridCardView", () => {
 			expect(symbol?.x).toBe(CARD_WIDTH / 2);
 		});
 
-		it("子要素が5つ（背景、シンボル、名前、コスト、効果）", () => {
+		it("子要素が4つ（背景、シンボル、名前、コスト）", () => {
 			const view = createGridCardView("attack");
-			expect(view.children.length).toBe(5);
+			expect(view.children.length).toBe(4);
 		});
 
 		it("CARD_WIDTHが90px、CARD_HEIGHTが120px", () => {

--- a/src/ui/gridCardView.ts
+++ b/src/ui/gridCardView.ts
@@ -6,19 +6,14 @@
 import { Container, Graphics, Text } from "pixi.js";
 import { getEffectiveCardCost } from "../game/debugCheats";
 import type { CardType } from "../types";
-import {
-	CARD_COLORS,
-	CARD_EFFECT_TEXT,
-	CARD_TYPE_NAME,
-	CARD_TYPE_SYMBOL,
-} from "./cardConstants";
+import { CARD_COLORS, CARD_TYPE_NAME, CARD_TYPE_SYMBOL } from "./cardConstants";
 import { drawRoundedRect } from "./graphicsHelpers";
 import { CARD_HEIGHT, CARD_RADIUS, CARD_WIDTH } from "./handRenderer";
 
 /**
  * グリッド表示用のカードビューを生成（インタラクションなし）
  *
- * 背景・シンボル・カード名・APコスト・効果テキストを描画する。
+ * 背景・シンボル・カード名・APコストを描画する。
  * インタラクション（タップ、ツールチップ等）は呼び出し側で追加すること。
  */
 export function createGridCardView(cardType: CardType): Container {
@@ -78,20 +73,6 @@ export function createGridCardView(cardType: CardType): Container {
 	costText.x = CARD_WIDTH / 2;
 	costText.y = 56;
 	cardContainer.addChild(costText);
-
-	// 効果テキスト
-	const effectText = new Text({
-		text: CARD_EFFECT_TEXT[cardType],
-		style: {
-			fontSize: 11,
-			fontFamily: "sans-serif",
-			fill: 0xaaaaaa,
-		},
-	});
-	effectText.anchor.set(0.5, 0);
-	effectText.x = CARD_WIDTH / 2;
-	effectText.y = 74;
-	cardContainer.addChild(effectText);
 
 	return cardContainer;
 }

--- a/src/ui/handRenderer.test.ts
+++ b/src/ui/handRenderer.test.ts
@@ -680,24 +680,6 @@ describe("カード種別ビジュアル差別化", () => {
 		});
 	});
 
-	describe("効果テキスト表示", () => {
-		it.each([
-			["move", "1マス移動"],
-			["attack", "1ダメージ"],
-			["strong_attack", "3ダメージ"],
-			["jump", "2マス先に着地"],
-			["wait", "-"],
-		] as [
-			CardType,
-			string,
-		][])("%s カードに効果テキスト「%s」が表示される", (type, expectedEffect) => {
-			const cardContainer = renderSingleCard(type);
-			const texts = getTextChildren(cardContainer);
-			const effectText = texts.find((t) => t.text === expectedEffect);
-			expect(effectText).toBeDefined();
-		});
-	});
-
 	describe("APコスト表示強化", () => {
 		it("コスト2のカードはAPコストが強調色で表示される", () => {
 			for (const type of allCardTypes) {

--- a/src/ui/handRenderer.ts
+++ b/src/ui/handRenderer.ts
@@ -9,7 +9,6 @@ import type { Card, CardType, Direction } from "../types";
 import { Easing, tween } from "../utils/tween";
 import {
 	CARD_COLORS as BASE_CARD_COLORS,
-	CARD_EFFECT_TEXT,
 	CARD_GLOW_COLORS,
 	CARD_TYPE_NAME,
 	CARD_TYPE_SYMBOL,
@@ -382,20 +381,6 @@ export class HandRenderer {
 		costText.x = CARD_WIDTH / 2;
 		costText.y = 56;
 		cardContainer.addChild(costText);
-
-		// 効果テキスト
-		const effectText = new Text({
-			text: CARD_EFFECT_TEXT[card.type],
-			style: {
-				fontSize: 11,
-				fontFamily: "sans-serif",
-				fill: enabled ? 0xaaaaaa : 0x555555,
-			},
-		});
-		effectText.anchor.set(0.5, 0);
-		effectText.x = CARD_WIDTH / 2;
-		effectText.y = 74;
-		cardContainer.addChild(effectText);
 
 		// 方向カードには方向ヒントを表示
 		if (

--- a/src/ui/rewardScreen.ts
+++ b/src/ui/rewardScreen.ts
@@ -9,7 +9,6 @@ import type { Card, CardType, Rarity } from "../types";
 import { Easing, tween } from "../utils/tween";
 import {
 	CARD_COLORS,
-	CARD_EFFECT_TEXT,
 	CARD_RARITY,
 	CARD_TYPE_NAME,
 	CARD_TYPE_SYMBOL,
@@ -526,20 +525,6 @@ export class RewardScreen {
 		costText.x = REWARD_CARD_WIDTH / 2;
 		costText.y = 78;
 		cardContainer.addChild(costText);
-
-		// 効果テキスト
-		const effect = new Text({
-			text: CARD_EFFECT_TEXT[cardType],
-			style: {
-				fontSize: 11,
-				fontFamily: "sans-serif",
-				fill: 0xaaaaaa,
-			},
-		});
-		effect.anchor.set(0.5, 0);
-		effect.x = REWARD_CARD_WIDTH / 2;
-		effect.y = 94;
-		cardContainer.addChild(effect);
 
 		return cardContainer;
 	}


### PR DESCRIPTION
## 概要
- カード本体に表示されていた `CARD_EFFECT_TEXT`（「1マス移動」「1ダメージ」等）を全4箇所の描画コードから削除
  - `handRenderer.ts` — 手札カードの効果テキスト描画を削除
  - `gridCardView.ts` — グリッド表示カードの効果テキスト描画を削除
  - `cardRowRenderer.ts` — 行表示の「効果テキスト / AP: コスト」をAPコストのみに変更
  - `rewardScreen.ts` — 報酬カードの効果テキスト描画を削除
- `cardConstants.ts` から `CARD_EFFECT_TEXT` 定数定義を削除
- テストコード4ファイルから効果テキスト関連テストを削除・APコスト表示テストに置換

Closes #424

## テスト計画
- [x] `pnpm format && pnpm lint` — Biomeチェック通過
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全1296テスト通過
- [ ] 手札カード・デッキ一覧・報酬画面・交換画面でカード本体に効果テキストが表示されないことを目視確認
- [ ] ツールチップホバーで詳細説明（CARD_DESCRIPTION）が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)