### PR TITLE
feat: コンボ判定・発動ロジックを実装

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -224,6 +224,12 @@ export const MAX_PLAY_SESSIONS = 50;
 export const FLOOR_AREA_SIZE = 5; // 5x5
 export const FLOOR_TILE_COUNT = FLOOR_AREA_SIZE * FLOOR_AREA_SIZE; // 25
 
+// コンボボーナス（v1.5）
+export const COMBO_BONUS = {
+	charge: 1,
+	chain: 1,
+} as const;
+
 // 特殊タイル効果（v1.3）
 export const TRAP_DAMAGE = 1;
 export const TREASURE_HEAL = 3;

--- a/src/game/action.ts
+++ b/src/game/action.ts
@@ -11,12 +11,19 @@ import {
 import type { Direction, GameState, Position, SpecialTileType } from "../types";
 import { DIRECTION_DELTA } from "../types";
 import { applyDamageToEnemy } from "./combat";
+import { detectCombo, getComboBonus } from "./combo";
 import { getEffectiveCardCost } from "./debugCheats";
 import { playCard } from "./deck";
 import { revealAtPosition } from "./fogOfWar";
 import { isInBounds } from "./map";
 import { recordCardUsage } from "./playStats";
-import { addActionLog, setDeck, setVisitedTiles, updatePlayer } from "./state";
+import {
+	addActionLog,
+	setDeck,
+	setVisitedTiles,
+	updateComboHistory,
+	updatePlayer,
+} from "./state";
 import { applyTileEffect } from "./tileEffect";
 
 /**
@@ -87,6 +94,12 @@ export function executeMove(
 	// AP消費 + カードを捨て札へ
 	let next = consumeApAndPlayCard(state, cardId, getEffectiveCardCost("move"));
 	recordCardUsage("move");
+
+	// comboHistory更新
+	next = updateComboHistory(next, {
+		lastCardType: "move",
+		lastDirection: direction,
+	});
 
 	// 移動判定
 	if (!canMove(state, direction)) {
@@ -187,6 +200,7 @@ export type AttackResult = {
  *
  * 成功/失敗に関わらずAP消費・カード使用を行う。
  * 成功時は敵にダメージ、HP0以下で敵を削除。
+ * コンボ判定は呼び出し元（executeAttack等）で行い、comboBonus引数で渡す。
  */
 function executeAttackBase(
 	state: GameState,
@@ -195,9 +209,16 @@ function executeAttackBase(
 	apCost: number,
 	damage: number,
 	missLog: string,
+	comboBonus: number,
+	comboLog: string | null,
 ): AttackResult {
 	// AP消費 + カードを捨て札へ
-	const next = consumeApAndPlayCard(state, cardId, apCost);
+	let next = consumeApAndPlayCard(state, cardId, apCost);
+
+	// コンボ発動ログ
+	if (comboLog) {
+		next = addActionLog(next, comboLog, "system");
+	}
 
 	// 攻撃判定（AP消費・カード使用後の状態で判定）
 	const result = canAttack(next, direction);
@@ -210,7 +231,8 @@ function executeAttackBase(
 	}
 
 	// 敵にダメージ（HP0以下で自動除去）
-	const damageResult = applyDamageToEnemy(next, result.enemyId, damage);
+	const totalDamage = damage + comboBonus;
+	const damageResult = applyDamageToEnemy(next, result.enemyId, totalDamage);
 
 	return {
 		state: damageResult.state,
@@ -219,6 +241,14 @@ function executeAttackBase(
 		overkill: damageResult.overkill,
 	};
 }
+
+/**
+ * コンボ種別に対応するログメッセージ
+ */
+const COMBO_LOG_MESSAGE: Record<string, string> = {
+	charge: "突撃コンボ発動！",
+	chain: "連撃コンボ発動！",
+};
 
 /**
  * 攻撃カード使用時のプレイヤー攻撃処理
@@ -233,14 +263,31 @@ export function executeAttack(
 	direction: Direction,
 ): AttackResult {
 	recordCardUsage("attack");
-	return executeAttackBase(
+
+	// コンボ判定（comboHistory更新前に判定）
+	const combo = detectCombo(state.comboHistory, "attack", direction);
+	const comboBonus = combo ? getComboBonus(combo) : 0;
+	const comboLog = combo ? (COMBO_LOG_MESSAGE[combo] ?? null) : null;
+
+	const result = executeAttackBase(
 		state,
 		cardId,
 		direction,
 		getEffectiveCardCost("attack"),
 		PLAYER_ATTACK_DAMAGE,
 		"攻撃できなかった",
+		comboBonus,
+		comboLog,
 	);
+
+	// comboHistory更新
+	return {
+		...result,
+		state: updateComboHistory(result.state, {
+			lastCardType: "attack",
+			lastDirection: direction,
+		}),
+	};
 }
 
 /**
@@ -249,6 +296,7 @@ export function executeAttack(
  * 成功/失敗に関わらずAP消費・カード使用を行う。
  * 成功時は敵に大ダメージを与え、HP0以下で敵を削除。
  * 戻り値の hit でヒット情報を返す。
+ * strong_attackはコンボ対象外（トリガーにも判定対象にもならない）。
  */
 export function executeStrongAttack(
 	state: GameState,
@@ -256,14 +304,25 @@ export function executeStrongAttack(
 	direction: Direction,
 ): AttackResult {
 	recordCardUsage("strong_attack");
-	return executeAttackBase(
+	const result = executeAttackBase(
 		state,
 		cardId,
 		direction,
 		getEffectiveCardCost("strong_attack"),
 		PLAYER_STRONG_ATTACK_DAMAGE,
 		"強攻撃できなかった",
+		0,
+		null,
 	);
+
+	// comboHistory更新（コンボ対象外だが履歴には記録）
+	return {
+		...result,
+		state: updateComboHistory(result.state, {
+			lastCardType: "strong_attack",
+			lastDirection: direction,
+		}),
+	};
 }
 
 /** ジャンプ実行結果 */
@@ -299,6 +358,12 @@ export function executeJump(
 	// AP消費 + カードを捨て札へ
 	let next = consumeApAndPlayCard(state, cardId, getEffectiveCardCost("jump"));
 	recordCardUsage("jump");
+
+	// comboHistory更新
+	next = updateComboHistory(next, {
+		lastCardType: "jump",
+		lastDirection: direction,
+	});
 
 	// 着地先（2マス先）の座標を計算
 	const landX = next.player.position.x + delta.x * JUMP_DISTANCE;
@@ -403,12 +468,14 @@ export function executeJump(
  */
 export function executeWait(state: GameState, cardId: string): GameState {
 	// AP消費 + カードを捨て札へ
-	const next = consumeApAndPlayCard(
-		state,
-		cardId,
-		getEffectiveCardCost("wait"),
-	);
+	let next = consumeApAndPlayCard(state, cardId, getEffectiveCardCost("wait"));
 	recordCardUsage("wait");
+
+	// comboHistory更新
+	next = updateComboHistory(next, {
+		lastCardType: "wait",
+		lastDirection: null,
+	});
 
 	return addActionLog(next, "待機した", "player");
 }

--- a/src/game/combo.test.ts
+++ b/src/game/combo.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { COMBO_BONUS } from "../constants";
+import type { ComboHistory } from "../types";
+import { detectCombo, getComboBonus } from "./combo";
+
+describe("detectCombo", () => {
+	it("ターン最初のカード（history=null）はコンボなし", () => {
+		expect(detectCombo(null, "attack", "up")).toBeNull();
+	});
+
+	it("move→attack 同方向で突撃コンボ", () => {
+		const history: ComboHistory = {
+			lastCardType: "move",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "attack", "up")).toBe("charge");
+	});
+
+	it("move→attack 異方向はコンボなし", () => {
+		const history: ComboHistory = {
+			lastCardType: "move",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "attack", "right")).toBeNull();
+	});
+
+	it("attack→attack で連撃コンボ", () => {
+		const history: ComboHistory = {
+			lastCardType: "attack",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "attack", "down")).toBe("chain");
+	});
+
+	it("attack→attack 同方向でも連撃コンボ", () => {
+		const history: ComboHistory = {
+			lastCardType: "attack",
+			lastDirection: "left",
+		};
+		expect(detectCombo(history, "attack", "left")).toBe("chain");
+	});
+
+	it("move→move はコンボなし", () => {
+		const history: ComboHistory = {
+			lastCardType: "move",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "move", "up")).toBeNull();
+	});
+
+	it("wait→attack はコンボなし", () => {
+		const history: ComboHistory = {
+			lastCardType: "wait",
+			lastDirection: null,
+		};
+		expect(detectCombo(history, "attack", "up")).toBeNull();
+	});
+
+	it("strong_attack→attack はコンボなし（strong_attackはattackではない）", () => {
+		const history: ComboHistory = {
+			lastCardType: "strong_attack",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "attack", "up")).toBeNull();
+	});
+
+	it("attack→strong_attack はコンボなし（strong_attackはattackではない）", () => {
+		const history: ComboHistory = {
+			lastCardType: "attack",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "strong_attack", "up")).toBeNull();
+	});
+
+	it("move→strong_attack はコンボなし（突撃はattackのみ）", () => {
+		const history: ComboHistory = {
+			lastCardType: "move",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "strong_attack", "up")).toBeNull();
+	});
+
+	it("jump→attack はコンボなし（jumpはmoveではない）", () => {
+		const history: ComboHistory = {
+			lastCardType: "jump",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "attack", "up")).toBeNull();
+	});
+
+	it("move→wait はコンボなし", () => {
+		const history: ComboHistory = {
+			lastCardType: "move",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "wait", null)).toBeNull();
+	});
+
+	it("attack→wait はコンボなし", () => {
+		const history: ComboHistory = {
+			lastCardType: "attack",
+			lastDirection: "up",
+		};
+		expect(detectCombo(history, "wait", null)).toBeNull();
+	});
+});
+
+describe("getComboBonus", () => {
+	it("突撃コンボのボーナスはCOMBO_BONUS.chargeと一致", () => {
+		expect(getComboBonus("charge")).toBe(COMBO_BONUS.charge);
+	});
+
+	it("連撃コンボのボーナスはCOMBO_BONUS.chainと一致", () => {
+		expect(getComboBonus("chain")).toBe(COMBO_BONUS.chain);
+	});
+});

--- a/src/game/combo.ts
+++ b/src/game/combo.ts
@@ -1,0 +1,50 @@
+/**
+ * コンボ判定ロジック
+ * @see docs/spec/combos.md
+ */
+
+import { COMBO_BONUS } from "../constants";
+import type { CardType, ComboHistory, ComboType, Direction } from "../types";
+
+/**
+ * 直前の使用履歴と現在のカード情報からコンボ種別を判定する
+ *
+ * - 突撃（charge）: move → attack（同方向）
+ * - 連撃（chain）: attack → attack
+ * - 「攻撃」は attack のみ（strong_attack は含まない）
+ * - 「移動」は move のみ（jump は含まない）
+ */
+export function detectCombo(
+	history: ComboHistory | null,
+	currentCardType: CardType,
+	currentDirection: Direction | null,
+): ComboType | null {
+	if (history === null) {
+		return null;
+	}
+
+	// 突撃: move → attack（同方向）
+	if (
+		history.lastCardType === "move" &&
+		currentCardType === "attack" &&
+		history.lastDirection !== null &&
+		currentDirection !== null &&
+		history.lastDirection === currentDirection
+	) {
+		return "charge";
+	}
+
+	// 連撃: attack → attack
+	if (history.lastCardType === "attack" && currentCardType === "attack") {
+		return "chain";
+	}
+
+	return null;
+}
+
+/**
+ * コンボ種別に応じたボーナス値を返す
+ */
+export function getComboBonus(comboType: ComboType): number {
+	return COMBO_BONUS[comboType];
+}

--- a/src/game/comboAction.test.ts
+++ b/src/game/comboAction.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { COMBO_BONUS, ENEMY_PARAMS, PLAYER_ATTACK_DAMAGE } from "../constants";
+import {
+	createTestEnemy,
+	createTestHand,
+	createTestState,
+	resetTestEnemySeq,
+} from "../test-utils/createTestFixtures";
+import type { GameState } from "../types";
+import { executeAttack, executeMove, executeWait } from "./action";
+
+describe("コンボ発動（統合テスト）", () => {
+	let state: GameState;
+
+	beforeEach(() => {
+		resetTestEnemySeq();
+		// プレイヤー(3,3)、敵(3,2)=上方向
+		const enemy = createTestEnemy("normal", { x: 3, y: 2 });
+		state = createTestState({
+			enemies: [enemy],
+			deck: {
+				deckOrder: [],
+				drawPile: [],
+				hand: createTestHand(["move", "attack", "attack"]),
+				discardPile: [],
+			},
+		});
+	});
+
+	it("移動→攻撃（同方向）で突撃コンボが発動しダメージが+1", () => {
+		// 移動: 上方向 (3,3)→(3,2)は敵がいるので移動失敗、だがカード使用扱い
+		const moveResult = executeMove(state, "test-card-0", "up");
+		const afterMove = moveResult.state;
+
+		// comboHistoryが更新されている
+		expect(afterMove.comboHistory).toEqual({
+			lastCardType: "move",
+			lastDirection: "up",
+		});
+
+		// 攻撃: 上方向（同方向）→突撃コンボ
+		const attackResult = executeAttack(afterMove, "test-card-1", "up");
+		const afterAttack = attackResult.state;
+
+		expect(attackResult.hit).toBe(true);
+
+		// 敵のHP: 初期HP - (基本ダメージ + コンボボーナス)
+		const expectedDamage = PLAYER_ATTACK_DAMAGE + COMBO_BONUS.charge;
+		const enemy = afterAttack.enemies.find((e) => e.id === "enemy-1");
+		if (enemy) {
+			expect(enemy.hp).toBe(ENEMY_PARAMS.normal.hp - expectedDamage);
+		}
+
+		// 行動ログにコンボ発動メッセージが含まれる
+		const comboLog = afterAttack.actionLog.find(
+			(log) => log.message === "突撃コンボ発動！",
+		);
+		expect(comboLog).toBeDefined();
+	});
+
+	it("移動→攻撃（異方向）ではコンボ不発でダメージは基本値", () => {
+		// プレイヤー(3,3)、敵を上(3,2)と右(4,3)に配置
+		resetTestEnemySeq();
+		const enemyUp = createTestEnemy("normal", { x: 3, y: 2 });
+		const enemyRight = createTestEnemy("normal", { x: 4, y: 3 });
+		const s = createTestState({
+			enemies: [enemyUp, enemyRight],
+			deck: {
+				deckOrder: [],
+				drawPile: [],
+				hand: createTestHand(["move", "attack", "attack"]),
+				discardPile: [],
+			},
+		});
+
+		// 移動: 上方向（敵がいて移動失敗、だがカード使用扱い）
+		const moveResult = executeMove(s, "test-card-0", "up");
+
+		// 攻撃: 右方向（異方向）→コンボ不発
+		const attackResult = executeAttack(
+			moveResult.state,
+			"test-card-1",
+			"right",
+		);
+		expect(attackResult.hit).toBe(true);
+
+		// 敵のHP: 初期HP - 基本ダメージのみ（コンボなし）
+		const enemyAfter = attackResult.state.enemies.find(
+			(e) => e.id === "enemy-2",
+		);
+		if (enemyAfter) {
+			expect(enemyAfter.hp).toBe(ENEMY_PARAMS.normal.hp - PLAYER_ATTACK_DAMAGE);
+		}
+
+		// コンボ発動ログがない
+		const comboLog = attackResult.state.actionLog.find(
+			(log) =>
+				log.message === "突撃コンボ発動！" ||
+				log.message === "連撃コンボ発動！",
+		);
+		expect(comboLog).toBeUndefined();
+	});
+
+	it("攻撃→攻撃で連撃コンボが発動しダメージが+1", () => {
+		// 敵(3,2)=上、敵(4,3)=右に2体配置
+		resetTestEnemySeq();
+		const enemy1 = createTestEnemy("normal", { x: 3, y: 2 });
+		const enemy2 = createTestEnemy("normal", { x: 4, y: 3 });
+		const s = createTestState({
+			enemies: [enemy1, enemy2],
+			deck: {
+				deckOrder: [],
+				drawPile: [],
+				hand: createTestHand(["attack", "attack", "attack"]),
+				discardPile: [],
+			},
+		});
+
+		// 1枚目: 上方向攻撃
+		const attack1 = executeAttack(s, "test-card-0", "up");
+		expect(attack1.hit).toBe(true);
+
+		// 2枚目: 右方向攻撃→連撃コンボ
+		const attack2 = executeAttack(attack1.state, "test-card-1", "right");
+		expect(attack2.hit).toBe(true);
+
+		// enemy2のHP: 初期HP - (基本ダメージ + コンボボーナス)
+		const expectedDamage = PLAYER_ATTACK_DAMAGE + COMBO_BONUS.chain;
+		const enemy = attack2.state.enemies.find((e) => e.id === "enemy-2");
+		if (enemy) {
+			expect(enemy.hp).toBe(ENEMY_PARAMS.normal.hp - expectedDamage);
+		}
+
+		// 連撃コンボログ
+		const comboLog = attack2.state.actionLog.find(
+			(log) => log.message === "連撃コンボ発動！",
+		);
+		expect(comboLog).toBeDefined();
+	});
+
+	it("ターン最初のカードではコンボが発動しない", () => {
+		// comboHistory=null の状態で攻撃
+		expect(state.comboHistory).toBeNull();
+
+		const attackResult = executeAttack(state, "test-card-1", "up");
+		expect(attackResult.hit).toBe(true);
+
+		// 敵のHP: 初期HP - 基本ダメージのみ
+		const enemy = attackResult.state.enemies.find((e) => e.id === "enemy-1");
+		if (enemy) {
+			expect(enemy.hp).toBe(ENEMY_PARAMS.normal.hp - PLAYER_ATTACK_DAMAGE);
+		}
+
+		// コンボログなし
+		const comboLog = attackResult.state.actionLog.find(
+			(log) =>
+				log.message === "突撃コンボ発動！" ||
+				log.message === "連撃コンボ発動！",
+		);
+		expect(comboLog).toBeUndefined();
+	});
+
+	it("攻撃→攻撃→攻撃で2枚目と3枚目にそれぞれ連撃コンボが発動", () => {
+		// 敵を3方向に配置
+		resetTestEnemySeq();
+		const enemy1 = createTestEnemy("normal", { x: 3, y: 2 }); // 上
+		const enemy2 = createTestEnemy("normal", { x: 4, y: 3 }); // 右
+		const enemy3 = createTestEnemy("normal", { x: 3, y: 4 }); // 下
+		const s = createTestState({
+			enemies: [enemy1, enemy2, enemy3],
+			deck: {
+				deckOrder: [],
+				drawPile: [],
+				hand: createTestHand(["attack", "attack", "attack"]),
+				discardPile: [],
+			},
+			player: {
+				position: { x: 3, y: 3 },
+				hp: 10,
+				maxHp: 10,
+				ap: 3,
+				maxAp: 3,
+			},
+		});
+
+		// 1枚目: 上方向（コンボなし）
+		const attack1 = executeAttack(s, "test-card-0", "up");
+
+		// 2枚目: 右方向（連撃コンボ）
+		const attack2 = executeAttack(attack1.state, "test-card-1", "right");
+		const enemy2After = attack2.state.enemies.find((e) => e.id === "enemy-2");
+		if (enemy2After) {
+			expect(enemy2After.hp).toBe(
+				ENEMY_PARAMS.normal.hp - (PLAYER_ATTACK_DAMAGE + COMBO_BONUS.chain),
+			);
+		}
+
+		// 3枚目: 下方向（連撃コンボ）
+		const attack3 = executeAttack(attack2.state, "test-card-2", "down");
+		const enemy3After = attack3.state.enemies.find((e) => e.id === "enemy-3");
+		if (enemy3After) {
+			expect(enemy3After.hp).toBe(
+				ENEMY_PARAMS.normal.hp - (PLAYER_ATTACK_DAMAGE + COMBO_BONUS.chain),
+			);
+		}
+
+		// コンボログが2回出ている
+		const comboLogs = attack3.state.actionLog.filter(
+			(log) => log.message === "連撃コンボ発動！",
+		);
+		expect(comboLogs).toHaveLength(2);
+	});
+
+	it("wait→攻撃ではコンボが発動しない", () => {
+		const waitState = executeWait(state, "test-card-0");
+		expect(waitState.comboHistory).toEqual({
+			lastCardType: "wait",
+			lastDirection: null,
+		});
+
+		const attackResult = executeAttack(waitState, "test-card-1", "up");
+
+		// コンボログなし
+		const comboLog = attackResult.state.actionLog.find(
+			(log) =>
+				log.message === "突撃コンボ発動！" ||
+				log.message === "連撃コンボ発動！",
+		);
+		expect(comboLog).toBeUndefined();
+	});
+});

--- a/src/game/floor.test.ts
+++ b/src/game/floor.test.ts
@@ -72,6 +72,7 @@ function createTestState(overrides?: Partial<GameState>): GameState {
 		lastAttackerEnemyType: null,
 		acquisitionCounters: createInitialCounters(),
 		cardExchangeState: null,
+		comboHistory: null,
 		...overrides,
 	};
 }

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -12,6 +12,7 @@ import {
 } from "../constants";
 import type {
 	ActionLogEntry,
+	ComboHistory,
 	DeckState,
 	Enemy,
 	EnemyType,
@@ -149,6 +150,7 @@ export function createTitleScreenState(seed?: number): GameState {
 		lastAttackerEnemyType: null,
 		acquisitionCounters: createInitialCounters(),
 		cardExchangeState: null,
+		comboHistory: null,
 	};
 }
 
@@ -190,6 +192,7 @@ export function createInitialGameState(
 		lastAttackerEnemyType: null,
 		acquisitionCounters: createInitialCounters(),
 		cardExchangeState: null,
+		comboHistory: null,
 	};
 }
 
@@ -324,6 +327,16 @@ export function setVisitedTiles(
 	visitedTiles: Set<string>,
 ): GameState {
 	return { ...state, visitedTiles, rng: cloneRng(state.rng) };
+}
+
+/**
+ * コンボ履歴を更新
+ */
+export function updateComboHistory(
+	state: GameState,
+	history: ComboHistory | null,
+): GameState {
+	return { ...state, comboHistory: history, rng: cloneRng(state.rng) };
 }
 
 /**

--- a/src/game/turn.ts
+++ b/src/game/turn.ts
@@ -7,7 +7,7 @@ import { TURN_START_AP } from "../constants";
 import type { GameState } from "../types";
 import { discardHand, drawCards } from "./deck";
 import { recordTurnEnd } from "./playStats";
-import { changeTurn, setDeck, updatePlayer } from "./state";
+import { changeTurn, setDeck, updateComboHistory, updatePlayer } from "./state";
 
 /**
  * プレイヤーターン開始処理
@@ -22,6 +22,9 @@ export function startPlayerTurn(state: GameState): GameState {
 		...p,
 		ap: TURN_START_AP,
 	}));
+
+	// コンボ履歴リセット
+	next = updateComboHistory(next, null);
 
 	// 手札補充
 	next = setDeck(next, drawCards(next.deck));

--- a/src/test-utils/createTestFixtures.ts
+++ b/src/test-utils/createTestFixtures.ts
@@ -53,6 +53,7 @@ export function createTestState(overrides?: Partial<GameState>): GameState {
 		lastAttackerEnemyType: null,
 		acquisitionCounters: createInitialCounters(),
 		cardExchangeState: null,
+		comboHistory: null,
 		...overrides,
 	};
 }

--- a/src/types/combo.ts
+++ b/src/types/combo.ts
@@ -1,0 +1,20 @@
+/**
+ * コンボシステムの型定義
+ * @see docs/spec/combos.md
+ */
+
+import type { CardType } from "./card";
+import type { Direction } from "./direction";
+
+/**
+ * コンボ種別
+ */
+export type ComboType = "charge" | "chain";
+
+/**
+ * ターン内カード使用履歴（直前1枚分）
+ */
+export type ComboHistory = {
+	lastCardType: CardType;
+	lastDirection: Direction | null;
+};

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -7,6 +7,7 @@ import type { RNG } from "../utils/rng";
 import type { DeckState } from "./card";
 import type { AcquisitionCounters, CardExchangeState } from "./cardAcquisition";
 import type { Enemy, EnemyType, Player } from "./character";
+import type { ComboHistory } from "./combo";
 import type { GameMap, Room } from "./map";
 
 /**
@@ -72,4 +73,6 @@ export type GameState = {
 	acquisitionCounters: AcquisitionCounters;
 	/** カード交換の保留状態（敵撃破時に条件達成した場合にセット） */
 	cardExchangeState: CardExchangeState;
+	/** ターン内カード使用履歴（コンボ判定用、ターン開始時にnullリセット） */
+	comboHistory: ComboHistory | null;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export type {
 	EnemyCardAcquisitionConfig,
 } from "./cardAcquisition";
 export type { Enemy, EnemyType, PendingSkillType, Player } from "./character";
+export type { ComboHistory, ComboType } from "./combo";
 export { DIRECTION_DELTA, type Direction, type Position } from "./direction";
 export type { ActionLogEntry, GameState, LogActor, Screen, Turn } from "./game";
 export type { GameMap, Room, SpecialTileType, Tile, TileType } from "./map";

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -272,6 +272,7 @@ export function loadGame(): GameState | null {
 				data.acquisitionCounters,
 			),
 			cardExchangeState: null,
+			comboHistory: null,
 		};
 
 		// 旧セーブデータ互換: deckOrderがない場合は全カードをID順でソートして生成


### PR DESCRIPTION
## 概要

- コンボシステムの仕様（`docs/spec/combos.md`）に基づき、判定・発動ロジックを実装
- `ComboType`（charge/chain）、`ComboHistory` 型を新規定義
- `GameState` に `comboHistory` フィールドを追加（ターン開始時にnullリセット）
- `detectCombo` / `getComboBonus` によるコンボ判定ロジック（`src/game/combo.ts`）
- `executeAttack` にコンボボーナス加算を統合（突撃: move→attack同方向 +1、連撃: attack→attack +1）
- 全 `execute*` 関数でカード使用後に `comboHistory` を更新
- `strong_attack` はコンボ対象外（トリガーにも判定対象にもならない）だが履歴には記録
- コンボ発動時に行動ログへ通知メッセージを出力
- `COMBO_BONUS` 定数を `constants.ts` に追加
- 旧セーブデータ互換対応（`storage.ts` で `comboHistory: null` を補完）
- ユニットテスト15件、統合テスト6件を追加（全1324テスト通過）

Closes #407

## テスト計画

- [ ] `pnpm test:run` で全1324テスト通過を確認
- [ ] `pnpm build` でTypeScriptビルドが通ること
- [ ] move→attack（同方向）で突撃コンボが発動すること
- [ ] attack→attack で連撃コンボが発動すること
- [ ] 異方向のmove→attackではコンボが発動しないこと
- [ ] ターン最初のカードではコンボが発動しないこと
- [ ] strong_attack がコンボのトリガー・対象にならないこと
- [ ] ターン開始時にcomboHistoryがリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)