### PR TITLE
refactor: noNonNullAssertionのリント警告を5件解消

### DIFF
--- a/src/game/cardQueue.ts
+++ b/src/game/cardQueue.ts
@@ -30,7 +30,8 @@ export function buildQueuedCardIndexMap(
 ): Map<string, number> {
 	const map = new Map<string, number>();
 	for (let i = 0; i < queue.length; i++) {
-		const item = queue[i]!;
+		const item = queue[i];
+		if (!item) continue;
 		map.set(item.card.id, i + 1);
 	}
 	return map;

--- a/src/game/map.ts
+++ b/src/game/map.ts
@@ -140,7 +140,8 @@ export function generateBSPMapPlacement(
 		// プレイヤー/敵はすべての床タイルからサンプリング
 		const playerEnemyCount = 1 + enemyCount;
 		const playerEnemySampled = rng.sample(floorPositions, playerEnemyCount);
-		const player = playerEnemySampled[0]!;
+		const player = playerEnemySampled[0];
+		if (!player) continue;
 		const enemies = playerEnemySampled.slice(1);
 
 		// 階段は部屋内の床タイルからサンプリング（通路に配置しない）
@@ -154,7 +155,8 @@ export function generateBSPMapPlacement(
 		);
 		if (roomFloorForStairs.length < STAIRS_COUNT) continue;
 		const stairsSampled = rng.sample(roomFloorForStairs, STAIRS_COUNT);
-		const stairs = stairsSampled[0]!;
+		const stairs = stairsSampled[0];
+		if (!stairs) continue;
 		map[stairs.y][stairs.x] = createStairsTile();
 
 		// 特殊タイルは部屋内の床タイルからサンプリング（既配置位置を除外）

--- a/src/ui/specialTileEffect.ts
+++ b/src/ui/specialTileEffect.ts
@@ -71,9 +71,11 @@ export class SpecialTileEffectManager {
 		const newStairsEffects = new Map<string, TileEffect>();
 
 		for (let y = 0; y < map.length; y++) {
-			const row = map[y]!;
+			const row = map[y];
+			if (!row) continue;
 			for (let x = 0; x < row.length; x++) {
-				const tile = row[x]!;
+				const tile = row[x];
+				if (!tile) continue;
 				const key = `${x},${y}`;
 
 				if (tile.type === "stairs") {


### PR DESCRIPTION
## 概要
- `src/game/cardQueue.ts`: 配列インデックスアクセスの`!`をガード節(`if (!item) continue`)に置換
- `src/game/map.ts`: `rng.sample()`結果の`!`をガード節に置換（2箇所）
- `src/ui/specialTileEffect.ts`: マップ行・タイルアクセスの`!`をガード節に置換（2箇所）

Closes #438

## テスト計画
- [x] `pnpm lint` で警告0件を確認
- [x] `pnpm build` でビルド成功を確認
- [x] `pnpm test:run` で全1346テストがパス
- [x] `pnpm test:e2e` でE2Eテストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)