### PR TITLE
fix: デッキ一覧・カード交換UIのグリッドを4列表示に変更

### DIFF
--- a/src/ui/deckViewer.test.ts
+++ b/src/ui/deckViewer.test.ts
@@ -146,7 +146,7 @@ describe("DeckViewer", () => {
 			const container = viewer.getContainer();
 			// children[2]が最初のカード（overlay=0, title=1）
 			const firstCard = container.children[2];
-			const gridWidth = 3 * CARD_WIDTH + 2 * CARD_GAP;
+			const gridWidth = 4 * CARD_WIDTH + 3 * CARD_GAP;
 			const expectedGridX = (gameAreaWidth - gridWidth) / 2;
 			expect(firstCard.x).toBe(expectedGridX);
 		});
@@ -168,7 +168,7 @@ describe("DeckViewer", () => {
 			const titleFontSize = 24;
 			const titleToGridGap = 12;
 			const allCards = deck.hand;
-			const gridRows = Math.ceil(allCards.length / 3);
+			const gridRows = Math.ceil(allCards.length / 4);
 			const gridHeight = gridRows * CARD_HEIGHT + (gridRows - 1) * CARD_GAP;
 			const gridToCloseGap = 10;
 			const contentHeight =

--- a/src/ui/deckViewer.ts
+++ b/src/ui/deckViewer.ts
@@ -38,7 +38,7 @@ const DECK_BUTTON_COLORS = {
 } as const;
 
 /** グリッドレイアウト定数 */
-const GRID_COLUMNS = 3;
+const GRID_COLUMNS = 4;
 
 /**
  * デッキ閲覧UIレンダラー

--- a/src/ui/rewardScreen.test.ts
+++ b/src/ui/rewardScreen.test.ts
@@ -287,7 +287,7 @@ describe("RewardScreen", () => {
 			expect(container.children.length).toBeGreaterThan(0);
 		});
 
-		it("グリッドコンテナにカードが3列で配置される", () => {
+		it("グリッドコンテナにカードが4列で配置される", () => {
 			const sixCards: Card[] = [
 				{ id: "c1", type: "move", keyword: "flame" },
 				{ id: "c2", type: "attack", keyword: "flame" },
@@ -304,21 +304,24 @@ describe("RewardScreen", () => {
 			expect(gridContainer).toBeDefined();
 			expect(gridContainer?.children.length).toBe(6);
 
-			// 1行目: 0,1,2 → col=0,1,2
+			// 1行目: 0,1,2,3 → col=0,1,2,3
 			const card0 = gridContainer?.children[0] as Container;
 			const card1 = gridContainer?.children[1] as Container;
 			const card2 = gridContainer?.children[2] as Container;
+			const card3 = gridContainer?.children[3] as Container;
 			expect(card0.x).toBe(0);
 			expect(card1.x).toBe(CARD_WIDTH + CARD_GAP);
 			expect(card2.x).toBe(2 * (CARD_WIDTH + CARD_GAP));
+			expect(card3.x).toBe(3 * (CARD_WIDTH + CARD_GAP));
 			expect(card0.y).toBe(0);
 			expect(card1.y).toBe(0);
 			expect(card2.y).toBe(0);
+			expect(card3.y).toBe(0);
 
-			// 2行目: 3,4,5 → row=1
-			const card3 = gridContainer?.children[3] as Container;
-			expect(card3.x).toBe(0);
-			expect(card3.y).toBe(CARD_HEIGHT + CARD_GAP);
+			// 2行目: 4,5 → row=1
+			const card4 = gridContainer?.children[4] as Container;
+			expect(card4.x).toBe(0);
+			expect(card4.y).toBe(CARD_HEIGHT + CARD_GAP);
 		});
 
 		it("acquiredCardType指定時に獲得候補カードが表示される", () => {

--- a/src/ui/rewardScreen.ts
+++ b/src/ui/rewardScreen.ts
@@ -65,7 +65,7 @@ const REMOVE_PARTICLE_COLORS = [0xff4444, 0xff6644, 0xcc2222];
 const REMOVE_PARTICLE_COUNT = 15;
 
 /** グリッドレイアウト定数 */
-const GRID_COLUMNS = 3;
+const GRID_COLUMNS = 4;
 
 /**
  * 報酬画面レンダラー


### PR DESCRIPTION
## 概要
- `deckViewer.ts` の `GRID_COLUMNS` を 3 → 4 に変更
- `rewardScreen.ts` の `GRID_COLUMNS` を 3 → 4 に変更
- 関連テストの期待値を4列レイアウトに合わせて更新

Closes #444

## テスト計画
- [x] ユニットテスト全1332件通過
- [x] E2Eテスト通過
- [x] ビルド成功
- [ ] 4枚が1段で表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)