### PR TITLE
fix: 獲得カードのアスペクト比を手札と統一

### DIFF
--- a/src/ui/rewardScreen.ts
+++ b/src/ui/rewardScreen.ts
@@ -36,7 +36,7 @@ import {
 
 /** カードサイズ */
 const REWARD_CARD_WIDTH = 120;
-const REWARD_CARD_HEIGHT = 190;
+const REWARD_CARD_HEIGHT = 160;
 const REWARD_CARD_RADIUS = 8;
 const REWARD_CARD_GAP = 20;
 


### PR DESCRIPTION
## Summary

Closes #450

- `REWARD_CARD_HEIGHT` を `190` → `160` に変更し、獲得カードのアスペクト比を手札カード（0.75）と統一
- 幅120は維持のため、交換画面でグリッドカード（90×120）より一回り大きい視認性は保持

## 変更内容

| カード | 幅 | 高さ | アスペクト比 (W/H) |
|--------|-----|------|---------------------|
| 手札カード | 90 | 120 | **0.75** |
| 獲得カード（変更前） | 120 | 190 | 0.63 |
| 獲得カード（変更後） | 120 | **160** | **0.75** |

## Test plan

- [x] `pnpm format` — フォーマットOK
- [x] `pnpm lint` — リントOK
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全82ファイル、1322テスト通過
- [x] `pnpm test:e2e` — E2Eテスト通過
- [ ] `pnpm dev` で報酬画面を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)