### PR TITLE
feat: 敵HP表示をタイルゲージ式の色変化に変更

### DIFF
--- a/src/ui/characterRenderer.test.ts
+++ b/src/ui/characterRenderer.test.ts
@@ -1,0 +1,163 @@
+import { Container, Graphics, Sprite } from "pixi.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CELL_SIZE } from "../constants";
+import { createTickerMock } from "../test-utils/mockPixi";
+import { createTweenMock, mockEasing } from "../test-utils/mockTween";
+import type { Enemy } from "../types";
+import {
+	CharacterRenderer,
+	type CharacterRendererCallbacks,
+} from "./characterRenderer";
+import { HP_GAUGE_BRIGHT_COLOR } from "./mapAnimationConstants";
+
+// --- mocks ---
+
+const tickerMock = createTickerMock();
+
+vi.mock("pixi.js", async () => {
+	const actual = await vi.importActual<typeof import("pixi.js")>("pixi.js");
+	return {
+		...actual,
+		Ticker: {
+			shared: {
+				add: (fn: (tick: { deltaMS: number }) => void) =>
+					tickerMock.shared.add(fn),
+				remove: (fn: (tick: { deltaMS: number }) => void) =>
+					tickerMock.shared.remove(fn),
+			},
+		},
+	};
+});
+
+vi.mock("../utils/tween", () => ({
+	Easing: mockEasing,
+	tween: createTweenMock(),
+}));
+
+vi.mock("./assetLoader", async () => {
+	const pixi = await vi.importActual<typeof import("pixi.js")>("pixi.js");
+	const dummyTexture = pixi.Texture.WHITE;
+	return {
+		getTileTexture: () => dummyTexture,
+		getPlayerTexture: () => dummyTexture,
+		getEnemyTexture: () => dummyTexture,
+	};
+});
+
+// --- helpers ---
+
+function createCallbacks(): CharacterRendererCallbacks {
+	return {
+		onEnemyPointerOver: vi.fn(),
+		onEnemyPointerOut: vi.fn(),
+		onBeforeEnemyDestroy: vi.fn(),
+	};
+}
+
+function createEnemy(
+	overrides: Partial<Enemy> & { id: string; hp: number; maxHp: number },
+): Enemy {
+	return {
+		type: "normal",
+		position: { x: 1, y: 1 },
+		...overrides,
+	};
+}
+
+/** Graphics の描画呼び出しを記録するスパイ */
+function spyOnGraphics(g: Graphics) {
+	const rectSpy = vi.spyOn(g, "rect");
+	const fillSpy = vi.spyOn(g, "fill");
+	const clearSpy = vi.spyOn(g, "clear");
+	return { rectSpy, fillSpy, clearSpy };
+}
+
+// --- tests ---
+
+describe("CharacterRenderer HPゲージ", () => {
+	let renderer: CharacterRenderer;
+	let enemiesContainer: Container;
+
+	beforeEach(() => {
+		tickerMock.reset();
+		const playerSprite = new Sprite();
+		enemiesContainer = new Container();
+		renderer = new CharacterRenderer(
+			playerSprite,
+			enemiesContainer,
+			createCallbacks(),
+		);
+	});
+
+	it("ゲージが敵コンテナのindex 0に挿入される", () => {
+		const enemy = createEnemy({ id: "e1", hp: 3, maxHp: 3 });
+		renderer.renderEnemies([enemy]);
+
+		const enemyContainer = renderer.getEnemyContainer("e1");
+		expect(enemyContainer).toBeDefined();
+		// index 0 はゲージ（Graphics）、index 1 はスプライト
+		expect(enemyContainer?.children[0]).toBeInstanceOf(Graphics);
+		expect(enemyContainer?.children[1]).toBeInstanceOf(Sprite);
+	});
+
+	it("HP満タン時: 明るい矩形がタイル全面を覆う", () => {
+		const enemy = createEnemy({ id: "e1", hp: 5, maxHp: 5 });
+		renderer.renderEnemies([enemy]);
+
+		const gauge = renderer.getEnemyContainer("e1")?.children[0] as Graphics;
+		const { rectSpy, fillSpy } = spyOnGraphics(gauge);
+
+		// 再描画して spy で検証
+		renderer.renderEnemies([enemy]);
+
+		expect(rectSpy).toHaveBeenCalledWith(0, 0, CELL_SIZE, CELL_SIZE);
+		expect(fillSpy).toHaveBeenCalledWith(HP_GAUGE_BRIGHT_COLOR);
+	});
+
+	it("HP半分時: 明るい矩形の高さ = CELL_SIZE * 0.5、y位置 = CELL_SIZE * 0.5", () => {
+		const enemy = createEnemy({ id: "e1", hp: 5, maxHp: 10 });
+		renderer.renderEnemies([enemy]);
+
+		const gauge = renderer.getEnemyContainer("e1")?.children[0] as Graphics;
+		const { rectSpy, fillSpy } = spyOnGraphics(gauge);
+
+		renderer.renderEnemies([enemy]);
+
+		const expectedHeight = CELL_SIZE * 0.5;
+		const expectedY = CELL_SIZE - expectedHeight;
+		expect(rectSpy).toHaveBeenCalledWith(
+			0,
+			expectedY,
+			CELL_SIZE,
+			expectedHeight,
+		);
+		expect(fillSpy).toHaveBeenCalledWith(HP_GAUGE_BRIGHT_COLOR);
+	});
+
+	it("HP 0時: clearのみで矩形描画なし", () => {
+		const enemy = createEnemy({ id: "e1", hp: 0, maxHp: 5 });
+		renderer.renderEnemies([enemy]);
+
+		const gauge = renderer.getEnemyContainer("e1")?.children[0] as Graphics;
+		const { rectSpy, fillSpy, clearSpy } = spyOnGraphics(gauge);
+
+		renderer.renderEnemies([enemy]);
+
+		expect(clearSpy).toHaveBeenCalled();
+		expect(rectSpy).not.toHaveBeenCalled();
+		expect(fillSpy).not.toHaveBeenCalled();
+	});
+
+	it("敵破棄時にゲージMapからも削除される", () => {
+		const enemy = createEnemy({ id: "e1", hp: 3, maxHp: 3 });
+		renderer.renderEnemies([enemy]);
+
+		// 敵が存在する
+		expect(renderer.getEnemyContainer("e1")).toBeDefined();
+
+		// 敵を除外して描画 → 破棄される
+		renderer.renderEnemies([]);
+
+		expect(renderer.getEnemyContainer("e1")).toBeUndefined();
+	});
+});

--- a/src/ui/characterRenderer.ts
+++ b/src/ui/characterRenderer.ts
@@ -3,7 +3,7 @@
  */
 
 import { Container, Graphics, Sprite } from "pixi.js";
-import { CELL_SIZE, COLORS } from "../constants";
+import { CELL_SIZE } from "../constants";
 import type { Direction, Enemy, Player, Position } from "../types";
 import { DIRECTION_DELTA } from "../types";
 import type { EnemyType } from "../types/character";
@@ -20,8 +20,7 @@ import {
 	ENEMY_MOVE_DURATION,
 	ENEMY_MOVE_STAGGER_DELAY,
 	ENEMY_PADDING,
-	HP_BAR_BG_COLOR,
-	HP_BAR_HEIGHT,
+	HP_GAUGE_BRIGHT_COLOR,
 	PLAYER_MOVE_DURATION,
 } from "./mapAnimationConstants";
 
@@ -43,7 +42,7 @@ export class CharacterRenderer {
 	private enemiesContainer: Container;
 	private isPlayerInitialized = false;
 	private enemyContainerMap: Map<string, Container> = new Map();
-	private enemyHpBarMap: Map<string, Graphics> = new Map();
+	private enemyHpGaugeMap: Map<string, Graphics> = new Map();
 	private enemyTypeMap: Map<string, EnemyType> = new Map();
 	private playerGridPos: Position = { x: 0, y: 0 };
 	private enemyGridPosMap: Map<string, Position> = new Map();
@@ -131,26 +130,6 @@ export class CharacterRenderer {
 	}
 
 	/**
-	 * 敵タイプに応じた色を取得（HPバー描画用）
-	 */
-	private getEnemyColor(type: EnemyType): number {
-		switch (type) {
-			case "normal":
-				return COLORS.enemyNormal;
-			case "heavy":
-				return COLORS.enemyHeavy;
-			case "scout":
-				return COLORS.enemyScout;
-			case "miniboss":
-				return COLORS.enemyMiniboss;
-			case "boss":
-				return COLORS.enemyBoss;
-			default:
-				return COLORS.enemyNormal;
-		}
-	}
-
-	/**
 	 * 敵1体分のコンテナを作成
 	 */
 	private createEnemyContainer(type: EnemyType, enemyId: string): Container {
@@ -177,31 +156,27 @@ export class CharacterRenderer {
 	}
 
 	/**
-	 * 敵のHPバーを描画・更新
+	 * 敵HPゲージを描画・更新（タイル全体を使った液体ゲージ）
 	 */
-	private renderHpBar(enemy: Enemy): void {
-		let hpBar = this.enemyHpBarMap.get(enemy.id);
+	private renderHpGauge(enemy: Enemy): void {
+		let gauge = this.enemyHpGaugeMap.get(enemy.id);
 		const enemyContainer = this.enemyContainerMap.get(enemy.id);
 		if (!enemyContainer) return;
 
-		if (!hpBar) {
-			hpBar = new Graphics();
-			this.enemyHpBarMap.set(enemy.id, hpBar);
-			enemyContainer.addChild(hpBar);
+		if (!gauge) {
+			gauge = new Graphics();
+			this.enemyHpGaugeMap.set(enemy.id, gauge);
+			enemyContainer.addChildAt(gauge, 0);
 		}
 
-		const padding = ENEMY_PADDING[enemy.type];
-		const barWidth = CELL_SIZE - padding * 2;
 		const hpRatio = Math.max(0, enemy.hp / enemy.maxHp);
-		const barY = padding - HP_BAR_HEIGHT - 2;
+		const gaugeHeight = hpRatio * CELL_SIZE;
+		const gaugeY = CELL_SIZE - gaugeHeight;
 
-		hpBar.clear();
-		hpBar.rect(padding, barY, barWidth, HP_BAR_HEIGHT);
-		hpBar.fill(HP_BAR_BG_COLOR);
+		gauge.clear();
 		if (hpRatio > 0) {
-			const color = this.getEnemyColor(enemy.type);
-			hpBar.rect(padding, barY, barWidth * hpRatio, HP_BAR_HEIGHT);
-			hpBar.fill(color);
+			gauge.rect(0, gaugeY, CELL_SIZE, gaugeHeight);
+			gauge.fill(HP_GAUGE_BRIGHT_COLOR);
 		}
 	}
 
@@ -216,7 +191,7 @@ export class CharacterRenderer {
 			enemyContainer.destroy({ children: true });
 		}
 		this.enemyContainerMap.delete(id);
-		this.enemyHpBarMap.delete(id);
+		this.enemyHpGaugeMap.delete(id);
 		this.enemyTypeMap.delete(id);
 		this.enemyGridPosMap.delete(id);
 		this.enemyDataMap.delete(id);
@@ -260,7 +235,7 @@ export class CharacterRenderer {
 			enemyContainer.x = pixelPos.x;
 			enemyContainer.y = pixelPos.y;
 
-			this.renderHpBar(enemy);
+			this.renderHpGauge(enemy);
 		}
 
 		return visibleEnemies;
@@ -351,7 +326,7 @@ export class CharacterRenderer {
 			container.destroy({ children: true });
 		}
 		this.enemyContainerMap.clear();
-		this.enemyHpBarMap.clear();
+		this.enemyHpGaugeMap.clear();
 		this.enemyTypeMap.clear();
 		this.enemyGridPosMap.clear();
 		this.enemyDataMap.clear();

--- a/src/ui/mapAnimationConstants.ts
+++ b/src/ui/mapAnimationConstants.ts
@@ -89,11 +89,8 @@ export const ENEMY_PADDING: Record<EnemyType, number> = {
 	boss: 4, // 最大サイズ
 };
 
-/** HPバーの高さ（px） */
-export const HP_BAR_HEIGHT = 6;
-
-/** HPバー背景色 */
-export const HP_BAR_BG_COLOR = 0x333333;
+/** HPゲージ明部の色（床タイル 0x3a3a3a より明るいグレー） */
+export const HP_GAUGE_BRIGHT_COLOR = 0x5a5a5a;
 
 /** コンボポップアップのフォントサイズ */
 export const COMBO_POPUP_FONT_SIZE = 20;

--- a/src/ui/mapRendererHpBar.test.ts
+++ b/src/ui/mapRendererHpBar.test.ts
@@ -1,5 +1,5 @@
 /**
- * マップレンダラーのテスト（HPバー・ツールチップ）
+ * マップレンダラーのテスト（HPゲージ・ツールチップ）
  */
 
 import "../test-utils/mapRendererTestSetup";
@@ -8,8 +8,8 @@ import { describe, expect, it, vi } from "vitest";
 import { createRendererTestMap } from "../test-utils/mapRendererTestSetup";
 import { MapRenderer } from "./mapRenderer";
 
-describe("MapRenderer HPバー", () => {
-	it("miniboss敵のコンテナにHPバーが含まれる", () => {
+describe("MapRenderer HPゲージ", () => {
+	it("miniboss敵のコンテナにHPゲージが含まれる", () => {
 		const renderer = new MapRenderer();
 		const map = createRendererTestMap();
 		const enemies = [
@@ -34,12 +34,12 @@ describe("MapRenderer HPバー", () => {
 		const enemiesContainer = container.children[4];
 		// 敵コンテナ1つ
 		expect(enemiesContainer.children.length).toBe(1);
-		// 敵コンテナ内にSprite(1) + HPバー(1) = 2
+		// 敵コンテナ内にSprite(1) + HPゲージ(1) = 2
 		const enemyContainer = enemiesContainer.children[0];
 		expect(enemyContainer.children.length).toBe(2);
 	});
 
-	it("boss敵のコンテナにHPバーが含まれる", () => {
+	it("boss敵のコンテナにHPゲージが含まれる", () => {
 		const renderer = new MapRenderer();
 		const map = createRendererTestMap();
 		const enemies = [
@@ -63,12 +63,12 @@ describe("MapRenderer HPバー", () => {
 		const container = renderer.getContainer();
 		const enemiesContainer = container.children[4];
 		expect(enemiesContainer.children.length).toBe(1);
-		// 敵コンテナ内にSprite(1) + HPバー(1) = 2
+		// 敵コンテナ内にSprite(1) + HPゲージ(1) = 2
 		const enemyContainer = enemiesContainer.children[0];
 		expect(enemyContainer.children.length).toBe(2);
 	});
 
-	it("normal敵のコンテナにもHPバーが含まれる", () => {
+	it("normal敵のコンテナにもHPゲージが含まれる", () => {
 		const renderer = new MapRenderer();
 		const map = createRendererTestMap();
 		const enemies = [
@@ -92,12 +92,12 @@ describe("MapRenderer HPバー", () => {
 		const container = renderer.getContainer();
 		const enemiesContainer = container.children[4];
 		expect(enemiesContainer.children.length).toBe(1);
-		// 敵コンテナ内にSprite(1) + HPバー(1) = 2
+		// 敵コンテナ内にSprite(1) + HPゲージ(1) = 2
 		const enemyContainer = enemiesContainer.children[0];
 		expect(enemyContainer.children.length).toBe(2);
 	});
 
-	it("heavy敵のコンテナにもHPバーが含まれる", () => {
+	it("heavy敵のコンテナにもHPゲージが含まれる", () => {
 		const renderer = new MapRenderer();
 		const map = createRendererTestMap();
 		const enemies = [
@@ -121,12 +121,12 @@ describe("MapRenderer HPバー", () => {
 		const container = renderer.getContainer();
 		const enemiesContainer = container.children[4];
 		expect(enemiesContainer.children.length).toBe(1);
-		// 敵コンテナ内にSprite(1) + HPバー(1) = 2
+		// 敵コンテナ内にSprite(1) + HPゲージ(1) = 2
 		const enemyContainer = enemiesContainer.children[0];
 		expect(enemyContainer.children.length).toBe(2);
 	});
 
-	it("scout敵のコンテナにもHPバーが含まれる", () => {
+	it("scout敵のコンテナにもHPゲージが含まれる", () => {
 		const renderer = new MapRenderer();
 		const map = createRendererTestMap();
 		const enemies = [
@@ -150,12 +150,12 @@ describe("MapRenderer HPバー", () => {
 		const container = renderer.getContainer();
 		const enemiesContainer = container.children[4];
 		expect(enemiesContainer.children.length).toBe(1);
-		// 敵コンテナ内にSprite(1) + HPバー(1) = 2
+		// 敵コンテナ内にSprite(1) + HPゲージ(1) = 2
 		const enemyContainer = enemiesContainer.children[0];
 		expect(enemyContainer.children.length).toBe(2);
 	});
 
-	it("HP減少が通常敵のHPバーに反映される", () => {
+	it("HP減少が通常敵のHPゲージに反映される", () => {
 		const renderer = new MapRenderer();
 		const map = createRendererTestMap();
 		const player = {
@@ -179,13 +179,12 @@ describe("MapRenderer HPバー", () => {
 		const rectSpy = vi.spyOn(Graphics.prototype, "rect");
 		renderer.render(map, player, fullHpEnemies);
 
-		// HPバー描画: 背景rect + HP部分rect
+		// HPゲージ描画: タイル全面のrect（幅=CELL_SIZE, 高さ=CELL_SIZE）
 		const fullHpCalls = rectSpy.mock.calls.filter(
-			(args) => args[2] !== undefined && args[3] === 6,
+			(args) => args[2] === 64 && args[3] === 64,
 		);
-		// 背景(幅40) + HP部分(幅40)
-		expect(fullHpCalls).toHaveLength(2);
-		const fullBarWidth = fullHpCalls[1][2] as number;
+		expect(fullHpCalls).toHaveLength(1);
+		const fullGaugeHeight = fullHpCalls[0][3] as number;
 
 		// HP減少して再描画
 		rectSpy.mockClear();
@@ -200,15 +199,13 @@ describe("MapRenderer HPバー", () => {
 		];
 		renderer.render(map, player, damagedEnemies);
 
-		const damagedHpCalls = rectSpy.mock.calls.filter(
-			(args) => args[2] !== undefined && args[3] === 6,
-		);
-		expect(damagedHpCalls).toHaveLength(2);
-		const damagedBarWidth = damagedHpCalls[1][2] as number;
+		// ゲージの高さが HP比率 に応じて縮小
+		const damagedCalls = rectSpy.mock.calls.filter((args) => args[2] === 64);
+		expect(damagedCalls).toHaveLength(1);
+		const damagedGaugeHeight = damagedCalls[0][3] as number;
 
-		// HP比率に応じてバー幅が縮小していること
-		expect(damagedBarWidth).toBeLessThan(fullBarWidth);
-		expect(damagedBarWidth).toBeCloseTo(fullBarWidth * (1 / 3), 5);
+		expect(damagedGaugeHeight).toBeLessThan(fullGaugeHeight);
+		expect(damagedGaugeHeight).toBeCloseTo(64 * (1 / 3), 5);
 
 		rectSpy.mockRestore();
 	});


### PR DESCRIPTION
## 概要
- 敵HPの表示方式を従来の6pxバーからタイル全体を使った液体ゲージに変更
- HP減少に応じて明るいグレー部分が下から縮小し、上から床タイルが露出する表現
- ゲージはグレースケール（0x5a5a5a）で統一し、敵タイプ別の色分けはスプライトテクスチャで維持
- 旧HPバー関連の定数（`HP_BAR_HEIGHT`, `HP_BAR_BG_COLOR`）と`getEnemyColor()`メソッドを削除
- `characterRenderer.test.ts`を新規作成し、ゲージの挿入位置・HP比率描画・破棄時クリーンアップを検証
- 既存の`mapRendererHpBar.test.ts`をゲージ方式に合わせて更新

Closes #452

## テスト計画
- [x] `pnpm lint` — リントエラーなし
- [x] `pnpm build` — TypeScriptビルド成功
- [x] `pnpm test:run` — 全1327テスト通過
- [ ] `pnpm dev` — 目視でゲージ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)