### PR TITLE
refactor: StatusBarからターン表示を削除

### DIFF
--- a/src/ui/eventHandlers.ts
+++ b/src/ui/eventHandlers.ts
@@ -699,11 +699,7 @@ export function setupEventHandlers(ctx: GameContext): void {
 
 			// 敵ターン状態を即座に反映（StatusBar/TurnEndButtonに反映）
 			applyState(ctx, next);
-			ctx.ui.statusBar.render(
-				ctx.state.floor,
-				ctx.state.turn,
-				ctx.state.isCleared,
-			);
+			ctx.ui.statusBar.render(ctx.state.floor, ctx.state.isCleared);
 			ctx.ui.turnEndButton.render(ctx.state.turn);
 
 			// 敵ターンバナー表示
@@ -750,11 +746,7 @@ export function setupEventHandlers(ctx: GameContext): void {
 
 				// バナー表示前にターン状態を反映（StatusBar/TurnEndButtonに即座に反映）
 				applyState(ctx, next);
-				ctx.ui.statusBar.render(
-					ctx.state.floor,
-					ctx.state.turn,
-					ctx.state.isCleared,
-				);
+				ctx.ui.statusBar.render(ctx.state.floor, ctx.state.isCleared);
 				ctx.ui.turnEndButton.render(ctx.state.turn);
 
 				// プレイヤーターンバナー表示

--- a/src/ui/gameRenderer.ts
+++ b/src/ui/gameRenderer.ts
@@ -108,7 +108,7 @@ export function renderGameScreen(
 	ctx.ui.gameOverScreen.hide();
 	ctx.ui.victoryScreen.hide();
 	ctx.ui.statusBar.show();
-	ctx.ui.statusBar.render(ctx.state.floor, ctx.state.turn, ctx.state.isCleared);
+	ctx.ui.statusBar.render(ctx.state.floor, ctx.state.isCleared);
 	const visitedTiles =
 		import.meta.env.DEV && getDebugCheats().fullMapVisible
 			? undefined

--- a/src/ui/statusBar.test.ts
+++ b/src/ui/statusBar.test.ts
@@ -21,13 +21,13 @@ describe("StatusBar", () => {
 		const statusBar = new StatusBar();
 		const container = statusBar.getContainer();
 		expect(container).toBeDefined();
-		// 2テキスト（階層 + ターン）
-		expect(container.children.length).toBe(2);
+		// 1テキスト（階層のみ）
+		expect(container.children.length).toBe(1);
 	});
 
 	it("renderで階層が正しく表示される", () => {
 		const statusBar = new StatusBar();
-		statusBar.render(5, "player");
+		statusBar.render(5);
 
 		const container = statusBar.getContainer();
 
@@ -36,34 +36,16 @@ describe("StatusBar", () => {
 
 	it("renderでisCleared=trueの場合に階層に★が付与される", () => {
 		const statusBar = new StatusBar();
-		statusBar.render(20, "player", true);
+		statusBar.render(20, true);
 
 		const container = statusBar.getContainer();
 
 		expect(findTextByPrefix(container, "階層:").text).toBe("階層: 20 ★");
 	});
 
-	it("renderでプレイヤーターン表示が正しい", () => {
-		const statusBar = new StatusBar();
-		statusBar.render(1, "player");
-
-		const container = statusBar.getContainer();
-		const turnText = findTextByPrefix(container, "あなた");
-		expect(turnText.text).toBe("あなたのターン");
-	});
-
-	it("renderで敵ターン表示が正しい", () => {
-		const statusBar = new StatusBar();
-		statusBar.render(1, "enemy");
-
-		const container = statusBar.getContainer();
-		const turnText = findTextByPrefix(container, "敵");
-		expect(turnText.text).toBe("敵のターン");
-	});
-
 	it("clearでテキストがクリアされる", () => {
 		const statusBar = new StatusBar();
-		statusBar.render(5, "player");
+		statusBar.render(5);
 		statusBar.clear();
 
 		const container = statusBar.getContainer();
@@ -91,7 +73,6 @@ describe("StatusBar", () => {
 		it("アニメーション完了後にHP比率が最終値に一致する", async () => {
 			vi.useFakeTimers();
 			const statusBar = new StatusBar();
-			statusBar.render(1, "player");
 
 			const promise = statusBar.animateHpChange(10, 7, 10);
 			await vi.advanceTimersByTimeAsync(1000);
@@ -104,7 +85,6 @@ describe("StatusBar", () => {
 		it("HP増加時もHP比率が変化する", async () => {
 			vi.useFakeTimers();
 			const statusBar = new StatusBar();
-			statusBar.render(1, "player");
 
 			const promise = statusBar.animateHpChange(5, 8, 10);
 			await vi.advanceTimersByTimeAsync(1000);
@@ -116,7 +96,6 @@ describe("StatusBar", () => {
 
 		it("値が変化しない場合は即座に完了する", async () => {
 			const statusBar = new StatusBar();
-			statusBar.render(1, "player");
 
 			await statusBar.animateHpChange(10, 10, 10);
 
@@ -126,7 +105,6 @@ describe("StatusBar", () => {
 		it("onHpUpdateコールバックが呼ばれる", async () => {
 			vi.useFakeTimers();
 			const statusBar = new StatusBar();
-			statusBar.render(1, "player");
 
 			const onHpUpdate = vi.fn();
 			const promise = statusBar.animateHpChange(10, 7, 10, onHpUpdate);
@@ -143,7 +121,6 @@ describe("StatusBar", () => {
 		it("tweenValueが1回だけ呼ばれる", async () => {
 			vi.useFakeTimers();
 			const statusBar = new StatusBar();
-			statusBar.render(1, "player");
 
 			mockTweenValue.mockClear();
 

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -1,25 +1,13 @@
 /**
  * ステータスバーUI
- * 階層番号、ターン表示
+ * 階層番号表示
  */
 
 import { Container, Text } from "pixi.js";
-import type { Turn } from "../types";
 import { Easing, tweenValue } from "../utils/tween";
-import { TURN_TEXT_COLORS } from "./turnColors";
 
 /** テキスト配置のX座標 */
 const FLOOR_TEXT_X = 16;
-const TURN_TEXT_X = 160;
-
-/** ターン別の表示テキスト */
-const TURN_TEXT: Record<Turn, string> = {
-	player: "あなたのターン",
-	enemy: "敵のターン",
-};
-
-/** ターン別のテキスト色（共通定数から参照） */
-const TURN_TEXT_COLOR = TURN_TEXT_COLORS;
 
 /** テキストのY座標 */
 const TEXT_Y = 12;
@@ -33,7 +21,6 @@ const TWEEN_DURATION = 300;
 export class StatusBar {
 	private container: Container;
 	private floorText: Text;
-	private turnText: Text;
 	private currentHpRatio = 0;
 
 	constructor() {
@@ -50,12 +37,6 @@ export class StatusBar {
 		this.floorText.y = TEXT_Y;
 		this.floorText.anchor.set(0, 0.5);
 		this.container.addChild(this.floorText);
-
-		this.turnText = new Text({ text: "", style: textStyle });
-		this.turnText.x = TURN_TEXT_X;
-		this.turnText.y = TEXT_Y;
-		this.turnText.anchor.set(0, 0.5);
-		this.container.addChild(this.turnText);
 	}
 
 	/**
@@ -75,11 +56,8 @@ export class StatusBar {
 	/**
 	 * ステータスバーを描画（即座にスナップ更新）
 	 */
-	render(floor: number, turn: Turn, isCleared = false): void {
+	render(floor: number, isCleared = false): void {
 		this.floorText.text = isCleared ? `階層: ${floor} ★` : `階層: ${floor}`;
-
-		this.turnText.text = TURN_TEXT[turn];
-		this.turnText.style.fill = TURN_TEXT_COLOR[turn];
 	}
 
 	/**
@@ -87,7 +65,6 @@ export class StatusBar {
 	 */
 	clear(): void {
 		this.floorText.text = "";
-		this.turnText.text = "";
 
 		this.currentHpRatio = 0;
 	}

--- a/src/ui/turnColors.ts
+++ b/src/ui/turnColors.ts
@@ -1,6 +1,6 @@
 /**
  * ターン別の共通配色定数
- * TurnBanner / StatusBar で共有する
+ * TurnBanner で使用
  */
 
 import type { Turn } from "../types";


### PR DESCRIPTION
## 概要
- StatusBarから「あなたのターン」「敵のターン」テキスト表示を削除
- `render()` の `turn` 引数を削除し、呼び出し元（gameRenderer, eventHandlers）を更新
- turnColors.tsのコメントをTurnBannerのみの参照に更新
- ターン表示関連のテストケースを削除

Closes #462

## テスト計画
- [x] StatusBarのユニットテストが全て通る（children数の検証を2→1に更新）
- [x] 全1306テスト通過
- [x] TypeScriptビルド成功
- [x] E2Eテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)