### PR TITLE
feat: プレイヤーアイコンにパディングを追加してタイルを視認可能にする

### DIFF
--- a/src/ui/characterRenderer.test.ts
+++ b/src/ui/characterRenderer.test.ts
@@ -8,7 +8,7 @@ import {
 	CharacterRenderer,
 	type CharacterRendererCallbacks,
 } from "./characterRenderer";
-import { HP_GAUGE_BRIGHT_COLOR } from "./mapAnimationConstants";
+import { HP_GAUGE_BRIGHT_COLOR, PLAYER_PADDING } from "./mapAnimationConstants";
 
 // --- mocks ---
 
@@ -205,6 +205,24 @@ describe("CharacterRenderer プレイヤーHPゲージ", () => {
 
 		expect(playerContainer.children[0]).toBeInstanceOf(Graphics);
 		expect(playerContainer.children[1]).toBeInstanceOf(Sprite);
+	});
+
+	it("プレイヤースプライトにパディングが適用されタイルが視認可能", () => {
+		const player = {
+			position: { x: 3, y: 3 },
+			hp: 10,
+			maxHp: 10,
+			ap: 3,
+			maxAp: 3,
+		};
+		renderer.renderPlayer(player);
+
+		const sprite = playerContainer.children[1] as Sprite;
+		const expectedSize = CELL_SIZE - PLAYER_PADDING * 2;
+		expect(sprite.width).toBe(expectedSize);
+		expect(sprite.height).toBe(expectedSize);
+		expect(sprite.x).toBe(PLAYER_PADDING);
+		expect(sprite.y).toBe(PLAYER_PADDING);
 	});
 
 	it("HP満タン時: ゲージがタイル全面を覆う", () => {

--- a/src/ui/characterRenderer.ts
+++ b/src/ui/characterRenderer.ts
@@ -22,6 +22,7 @@ import {
 	ENEMY_PADDING,
 	HP_GAUGE_BRIGHT_COLOR,
 	PLAYER_MOVE_DURATION,
+	PLAYER_PADDING,
 } from "./mapAnimationConstants";
 
 /**
@@ -89,8 +90,11 @@ export class CharacterRenderer {
 		this.playerContainer.addChild(gauge);
 
 		const sprite = new Sprite(getPlayerTexture());
-		sprite.width = CELL_SIZE;
-		sprite.height = CELL_SIZE;
+		const playerSize = CELL_SIZE - PLAYER_PADDING * 2;
+		sprite.x = PLAYER_PADDING;
+		sprite.y = PLAYER_PADDING;
+		sprite.width = playerSize;
+		sprite.height = playerSize;
 		this.playerContainer.addChild(sprite);
 
 		this.playerContainer.eventMode = "static";

--- a/src/ui/mapAnimationConstants.ts
+++ b/src/ui/mapAnimationConstants.ts
@@ -89,6 +89,9 @@ export const ENEMY_PADDING: Record<EnemyType, number> = {
 	boss: 4, // 最大サイズ
 };
 
+/** プレイヤーアイコンのパディング（セルサイズからの余白） */
+export const PLAYER_PADDING = 8;
+
 /** HPゲージ明部の色（床タイル 0x3a3a3a より明るいグレー） */
 export const HP_GAUGE_BRIGHT_COLOR = 0x5a5a5a;
 


### PR DESCRIPTION
## 概要
- `PLAYER_PADDING` 定数（8px）を `mapAnimationConstants.ts` に追加
- プレイヤースプライトにパディングを適用し、敵アイコンと同様にタイル背景が見えるようにした
- パディング適用を検証するユニットテストを追加

Closes #464

## テスト計画
- [x] プレイヤースプライトのサイズがパディング適用後の値であることを検証するテスト追加
- [x] 既存テスト全通過
- [x] E2Eテスト通過
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)