### PR TITLE
refactor: addActionLogのデフォルト引数を定数に統一

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+	ACTION_LOG_LIMIT,
 	ENEMY_PARAMS,
 	getEnemyComposition,
 	INITIAL_FLOOR,
@@ -339,7 +340,7 @@ export function addActionLog(
 	state: GameState,
 	message: string,
 	actor: LogActor = "system",
-	maxEntries = 50,
+	maxEntries = ACTION_LOG_LIMIT,
 ): GameState {
 	const entry: ActionLogEntry = {
 		id: crypto.randomUUID(),


### PR DESCRIPTION
## 概要
- `addActionLog`のデフォルト引数のハードコード`50`を`ACTION_LOG_LIMIT`定数に置換

Closes #480

## テスト計画
- [ ] 既存のユニットテストが全て通ること
- [ ] ビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)