### PR TITLE
refactor: ContainerTransform型と構築処理の共通化

### DIFF
--- a/src/ui/containerTransform.ts
+++ b/src/ui/containerTransform.ts
@@ -1,0 +1,9 @@
+/**
+ * コンテナの変換情報（カメラオフセット・ズーム）
+ * ツールチップ等の画面座標計算で使用
+ */
+export type ContainerTransform = {
+	x: number;
+	y: number;
+	scale: number;
+};

--- a/src/ui/enemyTooltip.ts
+++ b/src/ui/enemyTooltip.ts
@@ -12,6 +12,7 @@ import {
 } from "../constants";
 import type { EnemyAiAnalysis } from "../game/enemyAiAnalysis";
 import type { Enemy } from "../types";
+import type { ContainerTransform } from "./containerTransform";
 import { drawRoundedRect } from "./graphicsHelpers";
 
 /** ツールチップの枠線色 */
@@ -117,7 +118,7 @@ export class EnemyTooltip {
 			width: Number.POSITIVE_INFINITY,
 			height: Number.POSITIVE_INFINITY,
 		},
-		containerTransform: { x: number; y: number; scale: number } = {
+		containerTransform: ContainerTransform = {
 			x: 0,
 			y: 0,
 			scale: 1,
@@ -243,7 +244,7 @@ export class EnemyTooltip {
 		pixelX: number,
 		pixelY: number,
 		viewport: { width: number; height: number },
-		containerTransform: { x: number; y: number; scale: number },
+		containerTransform: ContainerTransform,
 	): void {
 		if (!this.container.visible) return;
 		this.applyPosition(pixelX, pixelY, viewport, containerTransform);
@@ -253,7 +254,7 @@ export class EnemyTooltip {
 		pixelX: number,
 		pixelY: number,
 		viewport: { width: number; height: number },
-		containerTransform: { x: number; y: number; scale: number },
+		containerTransform: ContainerTransform,
 	): void {
 		const { x: cx, y: cy, scale } = containerTransform;
 

--- a/src/ui/mapRenderer.ts
+++ b/src/ui/mapRenderer.ts
@@ -15,6 +15,7 @@ import type {
 	TileType,
 } from "../types";
 import { CharacterRenderer } from "./characterRenderer";
+import type { ContainerTransform } from "./containerTransform";
 import { getViewportPixelSize, gridToPixel } from "./coordinates";
 import {
 	animateDamagePopup as animateDamagePopupImpl,
@@ -378,6 +379,17 @@ export class MapRenderer {
 	}
 
 	/**
+	 * 現在のコンテナ変換情報を取得
+	 */
+	private getContainerTransform(): ContainerTransform {
+		return {
+			x: this.container.x,
+			y: this.container.y,
+			scale: this.container.scale.x,
+		};
+	}
+
+	/**
 	 * 敵ツールチップを表示
 	 */
 	private showEnemyTooltip(enemyId: string): void {
@@ -387,11 +399,7 @@ export class MapRenderer {
 
 		this.tooltipEnemyId = enemyId;
 		const viewport = getViewportPixelSize();
-		const containerTransform = {
-			x: this.container.x,
-			y: this.container.y,
-			scale: this.container.scale.x,
-		};
+		const containerTransform = this.getContainerTransform();
 		const debugInfo = this.enemyAiAnalyses.get(enemyId);
 		this.enemyTooltip.show(
 			enemy,
@@ -416,11 +424,7 @@ export class MapRenderer {
 		if (!enemyContainer) return;
 
 		const viewport = getViewportPixelSize();
-		const containerTransform = {
-			x: this.container.x,
-			y: this.container.y,
-			scale: this.container.scale.x,
-		};
+		const containerTransform = this.getContainerTransform();
 
 		this.enemyTooltip.updatePosition(
 			enemyContainer.x,
@@ -445,11 +449,7 @@ export class MapRenderer {
 		if (!this.lastPlayer) return;
 
 		const viewport = getViewportPixelSize();
-		const containerTransform = {
-			x: this.container.x,
-			y: this.container.y,
-			scale: this.container.scale.x,
-		};
+		const containerTransform = this.getContainerTransform();
 		this.playerTooltip.show(
 			this.lastPlayer,
 			this.playerContainer.x,
@@ -467,11 +467,7 @@ export class MapRenderer {
 		if (!this.playerTooltip.isVisible()) return;
 
 		const viewport = getViewportPixelSize();
-		const containerTransform = {
-			x: this.container.x,
-			y: this.container.y,
-			scale: this.container.scale.x,
-		};
+		const containerTransform = this.getContainerTransform();
 
 		this.playerTooltip.updatePosition(
 			this.playerContainer.x,
@@ -503,11 +499,7 @@ export class MapRenderer {
 		this.tooltipTileKey = key;
 		const pixelPos = gridToPixel({ x: gridX, y: gridY });
 		const viewport = getViewportPixelSize();
-		const containerTransform = {
-			x: this.container.x,
-			y: this.container.y,
-			scale: this.container.scale.x,
-		};
+		const containerTransform = this.getContainerTransform();
 		this.tileTooltip.show(
 			tileType,
 			pixelPos.x,
@@ -529,11 +521,7 @@ export class MapRenderer {
 		const gridY = Number(yStr);
 		const pixelPos = gridToPixel({ x: gridX, y: gridY });
 		const viewport = getViewportPixelSize();
-		const containerTransform = {
-			x: this.container.x,
-			y: this.container.y,
-			scale: this.container.scale.x,
-		};
+		const containerTransform = this.getContainerTransform();
 
 		this.tileTooltip.updatePosition(
 			pixelPos.x,

--- a/src/ui/playerTooltip.ts
+++ b/src/ui/playerTooltip.ts
@@ -6,6 +6,7 @@
 import { Container, Graphics, Text } from "pixi.js";
 import { CELL_SIZE } from "../constants";
 import type { Player } from "../types";
+import type { ContainerTransform } from "./containerTransform";
 import { drawRoundedRect } from "./graphicsHelpers";
 
 /** ツールチップの枠線色 */
@@ -85,7 +86,7 @@ export class PlayerTooltip {
 			width: Number.POSITIVE_INFINITY,
 			height: Number.POSITIVE_INFINITY,
 		},
-		containerTransform: { x: number; y: number; scale: number } = {
+		containerTransform: ContainerTransform = {
 			x: 0,
 			y: 0,
 			scale: 1,
@@ -129,7 +130,7 @@ export class PlayerTooltip {
 		pixelX: number,
 		pixelY: number,
 		viewport: { width: number; height: number },
-		containerTransform: { x: number; y: number; scale: number },
+		containerTransform: ContainerTransform,
 	): void {
 		if (!this.container.visible) return;
 		this.applyPosition(pixelX, pixelY, viewport, containerTransform);
@@ -139,7 +140,7 @@ export class PlayerTooltip {
 		pixelX: number,
 		pixelY: number,
 		viewport: { width: number; height: number },
-		containerTransform: { x: number; y: number; scale: number },
+		containerTransform: ContainerTransform,
 	): void {
 		const { x: cx, y: cy, scale } = containerTransform;
 

--- a/src/ui/tileTooltip.ts
+++ b/src/ui/tileTooltip.ts
@@ -6,6 +6,7 @@
 import { Container, Graphics, Text } from "pixi.js";
 import { CELL_SIZE, TRAP_DAMAGE, TREASURE_HEAL } from "../constants";
 import type { TileType } from "../types";
+import type { ContainerTransform } from "./containerTransform";
 import { drawRoundedRect } from "./graphicsHelpers";
 
 /** ツールチップの枠線色 */
@@ -107,7 +108,7 @@ export class TileTooltip {
 			width: Number.POSITIVE_INFINITY,
 			height: Number.POSITIVE_INFINITY,
 		},
-		containerTransform: { x: number; y: number; scale: number } = {
+		containerTransform: ContainerTransform = {
 			x: 0,
 			y: 0,
 			scale: 1,
@@ -159,7 +160,7 @@ export class TileTooltip {
 		pixelX: number,
 		pixelY: number,
 		viewport: { width: number; height: number },
-		containerTransform: { x: number; y: number; scale: number },
+		containerTransform: ContainerTransform,
 	): void {
 		if (!this.container.visible) return;
 		this.applyPosition(pixelX, pixelY, viewport, containerTransform);
@@ -169,7 +170,7 @@ export class TileTooltip {
 		pixelX: number,
 		pixelY: number,
 		viewport: { width: number; height: number },
-		containerTransform: { x: number; y: number; scale: number },
+		containerTransform: ContainerTransform,
 	): void {
 		const { x: cx, y: cy, scale } = containerTransform;
 


### PR DESCRIPTION
## 概要
- `ContainerTransform` 型を `src/ui/containerTransform.ts` に定義し、カメラオフセット・ズーム情報の型を一元化
- `mapRenderer.ts` の6箇所で重複していた `containerTransform` オブジェクト構築を `getContainerTransform()` プライベートメソッドに集約
- `enemyTooltip.ts`・`tileTooltip.ts`・`playerTooltip.ts` のインライン型宣言 `{ x: number; y: number; scale: number }` を共通の `ContainerTransform` 型参照に置換

Closes #484

## テスト計画
- [x] 既存のツールチップ関連テスト（enemyTooltip, playerTooltip, tileTooltip）が全てパス
- [x] mapRendererHpBar テストが全てパス
- [x] TypeScriptビルド（`pnpm build`）が成功
- [x] Biome lint/format がパス
- [x] e2eテスト（`pnpm test:e2e`）がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)