### PR TITLE
fix: カードアクション中の予約クリックがブロックされる問題を修正

### DIFF
--- a/src/ui/handRenderer.ts
+++ b/src/ui/handRenderer.ts
@@ -733,16 +733,26 @@ export class HandRenderer {
 
 		const cardContainer = this.cardsContainer.children[cardIndex] as Container;
 
-		Promise.resolve()
-			.then(invokeCallback)
+		// コールバックを同期的に呼び出し、即座にロックを解放する。
+		// これによりカードアクションアニメーション中（async待機中）でも予約クリックが通る。
+		// consumeアニメーション中は再ロックして二重クリックを防止する。
+		const callbackResult = invokeCallback();
+		this.isInputLocked = false;
+
+		Promise.resolve(callbackResult)
 			.then((result) => {
-				if (result === false) return;
-				return this.animateCardConsume(cardContainer, card.type);
+				if (result === false) {
+					this.render(this.currentHand);
+					return;
+				}
+				this.isInputLocked = true;
+				return this.animateCardConsume(cardContainer, card.type).finally(() => {
+					this.isInputLocked = false;
+					this.render(this.currentHand);
+				});
 			})
 			.catch((error) => {
 				console.error("onCardSelect callback failed:", error);
-			})
-			.finally(() => {
 				this.isInputLocked = false;
 				this.render(this.currentHand);
 			});


### PR DESCRIPTION
## 概要
- 攻撃モーション中に他のカードをクリックしても予約キューに入らないバグを修正
- `handRenderer.ts` の `isInputLocked` がasyncコールバック完了まで保持されていたため、カードアクションアニメーション中の予約クリックがブロックされていた
- コールバックを同期呼び出しに変更し、直後にロックを解放するよう修正
- consumeアニメーション開始時に再ロックすることで、二重クリック防止は維持

## テスト計画
- [x] `pnpm test:run` — 全1346テスト通過
- [x] `pnpm build` — ビルド成功
- [ ] 実機確認: 攻撃カード使用中に移動カードをクリックし、攻撃後に移動が実行されること
- [ ] 実機確認: 同じカードの二重クリックが防止されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)