### PR TITLE
fix: 特殊タイルのグロー円を削除しパーティクルのみ表示

### DIFF
--- a/src/ui/specialTileEffect.ts
+++ b/src/ui/specialTileEffect.ts
@@ -164,12 +164,6 @@ export class SpecialTileEffectManager {
 		this.graphics.clear();
 		this.particleGraphics.clear();
 
-		for (const effect of this.effects.values()) {
-			const alpha = calcPulseAlpha(this.elapsed, effect.config);
-			const radius = CELL_SIZE * effect.config.glowRadius;
-			this.graphics.circle(effect.px, effect.py, radius);
-			this.graphics.fill({ color: effect.config.glowColor, alpha });
-		}
 		for (const effect of this.stairsEffects.values()) {
 			const alpha = calcPulseAlpha(this.elapsed, effect.config);
 			const radius = CELL_SIZE * effect.config.glowRadius;


### PR DESCRIPTION
## 概要
- 特殊タイル（trap, treasure, rest_area）のグロー円描画を削除
- パーティクルエフェクトは引き続き表示される
- 階段タイルのグロー・矢印表示は変更なし

Closes #506

## テスト計画
- [x] `pnpm build` でビルドが成功する
- [x] `pnpm test:run` で既存テストが全通過する（specialTileEffect, specialTileEffectLogic含む）
- [x] `pnpm test:e2e` でE2Eテストが通過する
- [ ] 特殊タイル（罠・宝箱・休憩所）にグロー円が表示されないことを目視確認
- [ ] 特殊タイルにパーティクルエフェクトが表示されることを目視確認
- [ ] 階段タイルのグロー円と矢印が従来通り表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)