### PR TITLE
fix: コンボ攻撃時のダメージポップアップにボーナスを反映

### DIFF
--- a/src/ui/eventHandlers.ts
+++ b/src/ui/eventHandlers.ts
@@ -16,6 +16,7 @@ import {
 	startPlayerTurn,
 } from "../game";
 import { buildQueuedCardIndexMap, canEnqueueCard } from "../game/cardQueue";
+import { getComboBonus } from "../game/combo";
 import { resetDebugCheats } from "../game/debugCheats";
 import {
 	applyTileEffectWithDebug,
@@ -239,12 +240,14 @@ async function handleAttackCardExecution(
 		: undefined;
 
 	if (hit && enemyId) {
+		const comboBonus = comboType ? getComboBonus(comboType) : 0;
 		await updateStateWithAttackAnimation(
 			ctx,
 			next,
 			enemyId,
 			"attack",
 			overkill,
+			comboBonus,
 		);
 	} else {
 		await updateStateWithMissAnimation(ctx, next, direction);

--- a/src/ui/gameAnimations.test.ts
+++ b/src/ui/gameAnimations.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ダメージポップアップがコンボボーナスを反映するテスト
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	PLAYER_ATTACK_DAMAGE,
+	PLAYER_STRONG_ATTACK_DAMAGE,
+} from "../constants";
+
+// gameRenderer モック（applyState, renderを無効化）
+vi.mock("./gameRenderer", () => ({
+	applyState: vi.fn(),
+	render: vi.fn(),
+}));
+
+// exchangeFlow モック
+vi.mock("./exchangeFlow", () => ({
+	executeExchangeFlow: vi.fn(),
+}));
+
+// coordinates モック
+vi.mock("./coordinates", () => ({
+	getViewportPixelSize: () => ({ width: 800, height: 600 }),
+	gridToParticlePosition: () => ({ x: 0, y: 0 }),
+}));
+
+// battleParticles モック
+vi.mock("./battleParticles", () => ({
+	getAttackParticleConfig: vi.fn(() => ({})),
+	createDefeatParticleConfig: vi.fn(() => ({})),
+}));
+
+// layout モック
+vi.mock("./layout", () => ({
+	HAND_AREA_HEIGHT: 100,
+}));
+
+// tween モック
+vi.mock("../utils/tween", () => ({
+	Easing: { easeOutCubic: (t: number) => t },
+	tweenValue: vi.fn(() => Promise.resolve()),
+}));
+
+import type { GameContext } from "../gameContext";
+import type { GameState } from "../types";
+import { updateStateWithAttackAnimation } from "./gameAnimations";
+
+/**
+ * テスト用の最小限GameContextモックを作成
+ */
+function createMockCtx(
+	enemies: { id: string; position: { x: number; y: number } }[],
+): {
+	ctx: GameContext;
+	animateAttackHitSpy: ReturnType<typeof vi.fn>;
+} {
+	const animateAttackHitSpy = vi.fn(() => Promise.resolve());
+	const ctx = {
+		isAnimating: false,
+		state: {
+			enemies,
+		},
+		ui: {
+			cameraDragController: { reset: vi.fn() },
+			mapRenderer: {
+				getContainer: vi.fn(() => ({ x: 0, y: 0 })),
+				animateAttackHit: animateAttackHitSpy,
+				animateEnemyDefeat: vi.fn(() => Promise.resolve()),
+			},
+			particleSystem: {
+				getContainer: vi.fn(() => ({ x: 0, y: 0 })),
+				emit: vi.fn(() => Promise.resolve()),
+			},
+			actionLogRenderer: { getWidth: () => 200 },
+		},
+	} as unknown as GameContext;
+
+	return { ctx, animateAttackHitSpy };
+}
+
+describe("updateStateWithAttackAnimation ダメージポップアップ", () => {
+	it("通常攻撃でコンボなしの場合、基本ダメージのみをポップアップに渡す", async () => {
+		const enemyId = "e1";
+		const { ctx, animateAttackHitSpy } = createMockCtx([
+			{ id: enemyId, position: { x: 1, y: 0 } },
+		]);
+		const newState = {
+			enemies: [{ id: enemyId, position: { x: 1, y: 0 }, hp: 2 }],
+		} as unknown as GameState;
+
+		await updateStateWithAttackAnimation(ctx, newState, enemyId, "attack", 0);
+
+		expect(animateAttackHitSpy).toHaveBeenCalledWith(
+			enemyId,
+			PLAYER_ATTACK_DAMAGE,
+		);
+	});
+
+	it("通常攻撃でコンボボーナスがある場合、合計ダメージをポップアップに渡す", async () => {
+		const enemyId = "e1";
+		const comboBonus = 1;
+		const { ctx, animateAttackHitSpy } = createMockCtx([
+			{ id: enemyId, position: { x: 1, y: 0 } },
+		]);
+		const newState = {
+			enemies: [{ id: enemyId, position: { x: 1, y: 0 }, hp: 1 }],
+		} as unknown as GameState;
+
+		await updateStateWithAttackAnimation(
+			ctx,
+			newState,
+			enemyId,
+			"attack",
+			0,
+			comboBonus,
+		);
+
+		expect(animateAttackHitSpy).toHaveBeenCalledWith(
+			enemyId,
+			PLAYER_ATTACK_DAMAGE + comboBonus,
+		);
+	});
+
+	it("強攻撃ではコンボボーナスが加算されない（comboBonus未指定）", async () => {
+		const enemyId = "e1";
+		const { ctx, animateAttackHitSpy } = createMockCtx([
+			{ id: enemyId, position: { x: 1, y: 0 } },
+		]);
+		const newState = {
+			enemies: [{ id: enemyId, position: { x: 1, y: 0 }, hp: 1 }],
+		} as unknown as GameState;
+
+		await updateStateWithAttackAnimation(
+			ctx,
+			newState,
+			enemyId,
+			"strong_attack",
+			0,
+		);
+
+		expect(animateAttackHitSpy).toHaveBeenCalledWith(
+			enemyId,
+			PLAYER_STRONG_ATTACK_DAMAGE,
+		);
+	});
+});

--- a/src/ui/gameAnimations.ts
+++ b/src/ui/gameAnimations.ts
@@ -142,6 +142,7 @@ export async function updateStateWithBumpAnimation(
  * プレイヤー攻撃ヒット時のアニメーション付きで状態を更新
  * @param cardType 使用したカードタイプ（ダメージ値算出・パーティクル演出に使用）
  * @param overkill 超過ダメージ量（0で従来同等、正値で撃破演出が段階的に強化される）
+ * @param comboBonus コンボボーナスダメージ量（ダメージポップアップに反映）
  */
 export async function updateStateWithAttackAnimation(
 	ctx: GameContext,
@@ -149,6 +150,7 @@ export async function updateStateWithAttackAnimation(
 	hitEnemyId: string,
 	cardType: AttackCardType = "attack",
 	overkill = 0,
+	comboBonus = 0,
 ): Promise<void> {
 	if (ctx.isAnimating) return;
 	ctx.isAnimating = true;
@@ -165,10 +167,11 @@ export async function updateStateWithAttackAnimation(
 		render(ctx, false, false, defeated);
 
 		// ヒットエフェクト
-		const damage =
+		const baseDamage =
 			cardType === "strong_attack"
 				? PLAYER_STRONG_ATTACK_DAMAGE
 				: PLAYER_ATTACK_DAMAGE;
+		const damage = baseDamage + comboBonus;
 		const hitAnimations: Promise<void>[] = [
 			ctx.ui.mapRenderer.animateAttackHit(hitEnemyId, damage),
 		];


### PR DESCRIPTION
## 概要
- `updateStateWithAttackAnimation`に`comboBonus`引数を追加し、ダメージポップアップに反映
- `eventHandlers.ts`のコンボ攻撃時に`getComboBonus`でボーナス値を算出し渡すように修正
- ダメージポップアップのテストを追加（通常攻撃・コンボ攻撃・強攻撃の3ケース）

Closes #505

## テスト計画
- [ ] `pnpm test:run` でユニットテスト全通過を確認（1374テスト）
- [ ] `pnpm build` でビルド成功を確認
- [ ] `pnpm test:e2e` でE2Eテスト通過を確認
- [ ] 突進（charge）コンボ時にダメージポップアップが`-2`と表示されることを目視確認
- [ ] 連撃（chain）コンボ時にダメージポップアップが`-2`と表示されることを目視確認
- [ ] コンボなし通常攻撃時にダメージポップアップが`-1`と表示されることを確認
- [ ] 強攻撃時にダメージポップアップが`-2`と表示されることを確認（コンボ対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)