### PR TITLE
refactor: calcScreenShakeIntensityをmapEffectsに移動

### DIFF
--- a/src/ui/mapEffects.test.ts
+++ b/src/ui/mapEffects.test.ts
@@ -1,0 +1,33 @@
+/**
+ * 画面シェイク強度計算のテスト
+ */
+
+import { describe, expect, it } from "vitest";
+import { calcScreenShakeIntensity } from "./mapEffects";
+
+describe("calcScreenShakeIntensity", () => {
+	it("amount 1で基本強度4を返す", () => {
+		expect(calcScreenShakeIntensity(1)).toBe(4);
+	});
+
+	it("amount 3で基本強度より大きい値を返す", () => {
+		expect(calcScreenShakeIntensity(3)).toBeGreaterThan(4);
+	});
+
+	it("表示数値に応じて強度が増加する", () => {
+		expect(calcScreenShakeIntensity(3)).toBeGreaterThan(
+			calcScreenShakeIntensity(1),
+		);
+		expect(calcScreenShakeIntensity(5)).toBeGreaterThan(
+			calcScreenShakeIntensity(3),
+		);
+	});
+
+	it("上限値10を超えない", () => {
+		expect(calcScreenShakeIntensity(100)).toBe(10);
+	});
+
+	it("amount 0でも基本強度を返す", () => {
+		expect(calcScreenShakeIntensity(0)).toBe(4);
+	});
+});

--- a/src/ui/mapEffects.ts
+++ b/src/ui/mapEffects.ts
@@ -12,7 +12,24 @@ import {
 	PLAYER_BLINK_INTERVAL,
 	SCREEN_SHAKE_DURATION,
 } from "./mapAnimationConstants";
-import { BASE_SHAKE_INTENSITY } from "./popupLogic";
+
+/** 画面シェイク強度の基本値 */
+export const BASE_SHAKE_INTENSITY = 4;
+
+/** 画面シェイク強度の最大値 */
+const MAX_SHAKE_INTENSITY = 10;
+
+/** 表示数値1あたりのシェイク強度増加量 */
+const SHAKE_INTENSITY_PER_AMOUNT = 1.5;
+
+/**
+ * 表示数値（amount）に応じた画面シェイク強度を計算
+ * 数値が大きいほどシェイクが強い（上限あり）
+ */
+export function calcScreenShakeIntensity(amount: number): number {
+	const extra = Math.max(0, amount - 1) * SHAKE_INTENSITY_PER_AMOUNT;
+	return Math.min(BASE_SHAKE_INTENSITY + extra, MAX_SHAKE_INTENSITY);
+}
 
 /**
  * 対象に白フラッシュエフェクトを適用

--- a/src/ui/mapRenderer.ts
+++ b/src/ui/mapRenderer.ts
@@ -28,6 +28,7 @@ import {
 	animateFlash,
 	animatePlayerBlink,
 	animateScreenShake,
+	calcScreenShakeIntensity,
 } from "./mapEffects";
 import {
 	renderFog,
@@ -36,7 +37,6 @@ import {
 	type TileHoverCallbacks,
 } from "./mapTileRenderer";
 import { PlayerTooltip } from "./playerTooltip";
-import { calcScreenShakeIntensity } from "./popupLogic";
 import { SkillForecastEffectManager } from "./skillForecastEffect";
 import { SpecialTileEffectManager } from "./specialTileEffect";
 import { TileTooltip } from "./tileTooltip";

--- a/src/ui/popupLogic.test.ts
+++ b/src/ui/popupLogic.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { calcPopupFontSize, calcScreenShakeIntensity } from "./popupLogic";
+import { calcPopupFontSize } from "./popupLogic";
 
 describe("calcPopupFontSize", () => {
 	it("amount 1で基本サイズ24を返す", () => {
@@ -25,32 +25,5 @@ describe("calcPopupFontSize", () => {
 
 	it("amount 0でも基本サイズを返す", () => {
 		expect(calcPopupFontSize(0)).toBe(24);
-	});
-});
-
-describe("calcScreenShakeIntensity", () => {
-	it("amount 1で基本強度4を返す", () => {
-		expect(calcScreenShakeIntensity(1)).toBe(4);
-	});
-
-	it("amount 3で基本強度より大きい値を返す", () => {
-		expect(calcScreenShakeIntensity(3)).toBeGreaterThan(4);
-	});
-
-	it("表示数値に応じて強度が増加する", () => {
-		expect(calcScreenShakeIntensity(3)).toBeGreaterThan(
-			calcScreenShakeIntensity(1),
-		);
-		expect(calcScreenShakeIntensity(5)).toBeGreaterThan(
-			calcScreenShakeIntensity(3),
-		);
-	});
-
-	it("上限値10を超えない", () => {
-		expect(calcScreenShakeIntensity(100)).toBe(10);
-	});
-
-	it("amount 0でも基本強度を返す", () => {
-		expect(calcScreenShakeIntensity(0)).toBe(4);
 	});
 });

--- a/src/ui/popupLogic.ts
+++ b/src/ui/popupLogic.ts
@@ -11,15 +11,6 @@ const MAX_FONT_SIZE = 36;
 /** 表示数値1あたりのフォントサイズ増加量 */
 const FONT_SIZE_PER_AMOUNT = 3;
 
-/** 画面シェイク強度の基本値 */
-export const BASE_SHAKE_INTENSITY = 4;
-
-/** 画面シェイク強度の最大値 */
-const MAX_SHAKE_INTENSITY = 10;
-
-/** 表示数値1あたりのシェイク強度増加量 */
-const SHAKE_INTENSITY_PER_AMOUNT = 1.5;
-
 /**
  * 表示数値（amount）に応じたポップアップフォントサイズを計算
  * 数値が大きいほどフォントサイズが増加（上限あり）
@@ -27,13 +18,4 @@ const SHAKE_INTENSITY_PER_AMOUNT = 1.5;
 export function calcPopupFontSize(amount: number): number {
 	const extra = Math.max(0, amount - 1) * FONT_SIZE_PER_AMOUNT;
 	return Math.min(BASE_FONT_SIZE + extra, MAX_FONT_SIZE);
-}
-
-/**
- * 表示数値（amount）に応じた画面シェイク強度を計算
- * 数値が大きいほどシェイクが強い（上限あり）
- */
-export function calcScreenShakeIntensity(amount: number): number {
-	const extra = Math.max(0, amount - 1) * SHAKE_INTENSITY_PER_AMOUNT;
-	return Math.min(BASE_SHAKE_INTENSITY + extra, MAX_SHAKE_INTENSITY);
 }


### PR DESCRIPTION
## 概要
`calcScreenShakeIntensity` 関数と関連定数（`BASE_SHAKE_INTENSITY`、`MAX_SHAKE_INTENSITY`、`SHAKE_INTENSITY_PER_AMOUNT`）を `popupLogic.ts` から `mapEffects.ts` に移動。

画面シェイク強度の計算はポップアップ表示ロジックではなく、画面エフェクトの責務であるため、適切なモジュールに配置する。

## 変更内容
- `src/ui/mapEffects.ts`: シェイク強度の定数3つと `calcScreenShakeIntensity` 関数を追加
- `src/ui/popupLogic.ts`: シェイク関連の定数・関数を削除（ポップアップフォントサイズ計算のみ残す）
- `src/ui/mapRenderer.ts`: `calcScreenShakeIntensity` のimport元を `popupLogic` → `mapEffects` に変更
- `src/ui/mapEffects.test.ts`: シェイク強度計算テストを新規作成（`popupLogic.test.ts` から移動）
- `src/ui/popupLogic.test.ts`: シェイク強度テストを削除

## テスト計画
- [x] `pnpm test:run` で全1479テスト通過
- [x] `pnpm build` でビルド成功
- [x] `pnpm lint` でリントエラーなし

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)