### PR TITLE
fix: ベンチマーク実行時間の単位をmsに統一し表示を改善

### DIFF
--- a/scripts/compare-benchmarks.js
+++ b/scripts/compare-benchmarks.js
@@ -24,8 +24,9 @@ export function formatBytes(bytes) {
 }
 
 export function formatTime(ms) {
-	if (ms < 1) return `${(ms * 1000).toFixed(1)}μs`;
-	return `${ms.toFixed(2)}ms`;
+	if (ms === 0) return "0.000";
+	if (ms > 0 && ms < 0.001) return "<0.001";
+	return `${ms.toFixed(3)}`;
 }
 
 export function determineBestUnit(values) {
@@ -59,7 +60,7 @@ export function formatByteDiff(diff, pct) {
 
 export function formatTimeDiff(diff, pct) {
 	if (pct === "new") return "new";
-	if (diff === 0) return "変化なし";
+	if (Math.abs(diff) <= 0.001) return "変化なし";
 	const pctNum = Number(pct);
 	const sign = pctNum > 0 ? "+" : "-";
 	const absPct = Math.abs(pctNum).toFixed(1);
@@ -215,7 +216,7 @@ if (process.argv[1] === __filename) {
 		const bench = compareBenchmarks(base, head);
 		if (bench.rows) {
 			md += "### 実行時間ベンチマーク\n\n";
-			md += "| ベンチマーク | base | head | 差分 |\n";
+			md += "| ベンチマーク | base(ms) | head(ms) | 差分(ms) |\n";
 			md += "|-------------|------|------|------|\n";
 			md += bench.rows;
 			if (bench.hasRegression) {

--- a/scripts/compare-benchmarks.test.js
+++ b/scripts/compare-benchmarks.test.js
@@ -49,20 +49,21 @@ describe("formatBytes", () => {
 });
 
 describe("formatTime", () => {
-	it("1ms未満の値をμs単位で表示する", () => {
-		expect(formatTime(0.001)).toBe("1.0μs");
-		expect(formatTime(0.0001)).toBe("0.1μs");
-		expect(formatTime(0.1)).toBe("100.0μs");
+	it("常にms単位で表示する", () => {
+		expect(formatTime(1.5)).toBe("1.500");
+		expect(formatTime(10)).toBe("10.000");
+		expect(formatTime(1)).toBe("1.000");
+		expect(formatTime(0.1)).toBe("0.100");
+		expect(formatTime(0.001)).toBe("0.001");
 	});
 
-	it("1ms以上の値をms単位で表示する", () => {
-		expect(formatTime(1.5)).toBe("1.50ms");
-		expect(formatTime(10)).toBe("10.00ms");
-		expect(formatTime(1)).toBe("1.00ms");
+	it("0.001ms未満の値は<0.001と表示する", () => {
+		expect(formatTime(0.0001)).toBe("<0.001");
+		expect(formatTime(0.0009)).toBe("<0.001");
 	});
 
-	it("0を渡した場合はμs単位で0.0μsを返す", () => {
-		expect(formatTime(0)).toBe("0.0μs");
+	it("0を渡した場合は0.000を返す", () => {
+		expect(formatTime(0)).toBe("0.000");
 	});
 });
 
@@ -125,16 +126,18 @@ describe("formatTimeDiff", () => {
 		expect(formatTimeDiff(0.001, "new")).toBe("new");
 	});
 
-	it("μs単位で差分をフォーマットする", () => {
-		expect(formatTimeDiff(0.001, "5.0")).toBe("+1.0μs (+5.0%)");
-	});
-
 	it("ms単位で差分をフォーマットする", () => {
-		expect(formatTimeDiff(1.5, "10.0")).toBe("+1.50ms (+10.0%)");
+		expect(formatTimeDiff(1.5, "10.0")).toBe("+1.500 (+10.0%)");
+		expect(formatTimeDiff(0.005, "5.0")).toBe("+0.005 (+5.0%)");
 	});
 
 	it("差分ゼロの場合は「変化なし」を返す", () => {
 		expect(formatTimeDiff(0, "0.0")).toBe("変化なし");
+	});
+
+	it("差分の絶対値が0.001ms以下の場合は「変化なし」を返す", () => {
+		expect(formatTimeDiff(0.001, "0.5")).toBe("変化なし");
+		expect(formatTimeDiff(-0.0005, "-0.1")).toBe("変化なし");
 	});
 });
 
@@ -249,7 +252,7 @@ describe("compareBenchmarks", () => {
 		}
 	});
 
-	it("時間の単位がμs/msで自動切替される", () => {
+	it("すべての値がms単位で統一表示される", () => {
 		const result = compareBenchmarks(
 			{
 				files: [
@@ -281,8 +284,7 @@ describe("compareBenchmarks", () => {
 			},
 		);
 
-		expect(result.rows).toContain("μs");
-		expect(result.rows).toContain("ms");
+		expect(result.rows).not.toContain("μs");
 	});
 
 	it("20%以上劣化した場合に警告アイコンが表示される", () => {


### PR DESCRIPTION
## 概要
- `formatTime()` を常にms単位（小数点以下3桁）で表示するよう変更
- 0.001ms未満の値は `<0.001` と表示
- テーブルヘッダーに `base(ms)`, `head(ms)`, `差分(ms)` と単位を表示
- `formatTimeDiff()` で差分の絶対値が0.001ms以下の場合「変化なし」と判定
- 対応テストを更新

Closes #548

## テスト計画
- [x] `formatTime()` が常にms単位で表示する
- [x] 0.001ms未満の値は `<0.001` と表示する
- [x] `formatTimeDiff()` で微小差分が「変化なし」になる
- [x] 既存テストが全て通過する
- [x] E2Eテストが通過する

🤖 Generated with [Claude Code](https://claude.com/claude-code)