### PR TITLE
feat: 連続性のある発話（直前イベント参照）を追加

### DIFF
--- a/src/game/speech.test.ts
+++ b/src/game/speech.test.ts
@@ -10,7 +10,7 @@ import { createTestState } from "../test-utils/createTestFixtures";
 import type { Personality } from "../types";
 import { CONTEXTUAL_SPEECH_VARIANTS } from "./contextualSpeechData";
 import { addSpeechLog, matchesContext } from "./speech";
-import { SPEECH_VARIANTS } from "./speechData";
+import { SPEECH_SEQUENCE_VARIANTS, SPEECH_VARIANTS } from "./speechData";
 
 describe("addSpeechLog", () => {
 	it("発話ログがstateに設定される", () => {
@@ -59,6 +59,50 @@ describe("addSpeechLog", () => {
 		const next = addSpeechLog(state, "move_success");
 		const variants = SPEECH_VARIANTS[personality].move_success;
 		expect(variants).toContain(next.speechLog?.message);
+	});
+
+	it("連続パターン一致時にSPEECH_SEQUENCE_VARIANTSから選択される", () => {
+		const state = createTestState();
+		const s1 = addSpeechLog(state, "damage_taken");
+		const s2 = addSpeechLog(s1, "enemy_defeated");
+		const seqVariants =
+			SPEECH_SEQUENCE_VARIANTS[DEFAULT_PERSONALITY].damage_taken_enemy_defeated;
+		expect(seqVariants).toContain(s2.speechLog?.message);
+	});
+
+	it("連続パターン未定義時に通常発話にフォールバックする", () => {
+		const state = createTestState();
+		const s1 = addSpeechLog(state, "move_success");
+		// move_success → move_success は連続パターン未定義
+		const s2 = addSpeechLog(s1, "move_success");
+		const variants = SPEECH_VARIANTS[DEFAULT_PERSONALITY].move_success;
+		expect(variants).toContain(s2.speechLog?.message);
+	});
+
+	it("speechLogがnull（初回）の場合は通常発話が選択される", () => {
+		const state = createTestState();
+		expect(state.speechLog).toBeNull();
+		const next = addSpeechLog(state, "enemy_defeated");
+		const variants = SPEECH_VARIANTS[DEFAULT_PERSONALITY].enemy_defeated;
+		expect(variants).toContain(next.speechLog?.message);
+	});
+
+	it("連続発話でもeventTypeは現在イベントが記録される", () => {
+		const state = createTestState();
+		const s1 = addSpeechLog(state, "damage_taken");
+		const s2 = addSpeechLog(s1, "enemy_defeated");
+		expect(s2.speechLog?.eventType).toBe("enemy_defeated");
+	});
+
+	it.each(
+		PERSONALITIES,
+	)("性格 %s で連続発話が動作する", (personality: Personality) => {
+		const state = createTestState({ personality });
+		const s1 = addSpeechLog(state, "damage_taken");
+		const s2 = addSpeechLog(s1, "enemy_defeated");
+		const seqVariants =
+			SPEECH_SEQUENCE_VARIANTS[personality].damage_taken_enemy_defeated;
+		expect(seqVariants).toContain(s2.speechLog?.message);
 	});
 });
 

--- a/src/game/speech.ts
+++ b/src/game/speech.ts
@@ -13,7 +13,7 @@ import {
 	CONTEXTUAL_SPEECH_VARIANTS,
 	type SpeechContext,
 } from "./contextualSpeechData";
-import { SPEECH_VARIANTS } from "./speechData";
+import { SPEECH_SEQUENCE_VARIANTS, SPEECH_VARIANTS } from "./speechData";
 import { setSpeechLog } from "./state";
 
 /**
@@ -39,14 +39,27 @@ export function matchesContext(
 }
 
 /**
- * 発話ログを追加（コンテキスト別バリエーション優先、フォールバックはデフォルト）
+ * 発話ログを追加（連続発話 > コンテキスト発話 > デフォルトの優先順位）
  *
+ * 直前イベントとの組み合わせで連続発話パターンがあればそちらを最優先。
  * Math.random()を使用し、ゲームRNGには影響しない。
  */
 export function addSpeechLog(
 	state: GameState,
 	eventType: SpeechEventType,
 ): GameState {
+	// 1. 連続発話パターン（直前イベント参照）
+	const prevEventType = state.speechLog?.eventType;
+	if (prevEventType) {
+		const key = `${prevEventType}_${eventType}` as const;
+		const seqVariants = SPEECH_SEQUENCE_VARIANTS[state.personality][key];
+		if (seqVariants && seqVariants.length > 0) {
+			const index = Math.floor(Math.random() * seqVariants.length);
+			return setSpeechLog(state, eventType, seqVariants[index]);
+		}
+	}
+
+	// 2. コンテキスト発話
 	const contextualEntries =
 		CONTEXTUAL_SPEECH_VARIANTS[state.personality][eventType];
 
@@ -60,9 +73,8 @@ export function addSpeechLog(
 		}
 	}
 
-	// フォールバック: デフォルトバリエーション
+	// 3. フォールバック: デフォルトバリエーション
 	const variants = SPEECH_VARIANTS[state.personality][eventType];
 	const index = Math.floor(Math.random() * variants.length);
-	const message = variants[index];
-	return setSpeechLog(state, eventType, message);
+	return setSpeechLog(state, eventType, variants[index]);
 }

--- a/src/game/speechData.test.ts
+++ b/src/game/speechData.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { PERSONALITIES } from "../constants";
 import type { Personality, SpeechEventType } from "../types";
-import { SPEECH_VARIANTS } from "./speechData";
+import { SPEECH_SEQUENCE_VARIANTS, SPEECH_VARIANTS } from "./speechData";
 
 const eventTypes: SpeechEventType[] = [
 	"move_success",
@@ -39,7 +39,7 @@ describe("SPEECH_VARIANTS", () => {
 		}
 	});
 
-	it("性格間で発話内容が異なる", () => {
+	it("性格間で発話内容が異なる（通常発話）", () => {
 		for (const eventType of eventTypes) {
 			const allVariantSets = PERSONALITIES.map(
 				(p) => new Set(SPEECH_VARIANTS[p][eventType]),
@@ -54,6 +54,50 @@ describe("SPEECH_VARIANTS", () => {
 						[...set].some((v) => !firstSet.has(v)),
 				);
 			expect(hasDifference).toBe(true);
+		}
+	});
+});
+
+const sequenceKeys = [
+	"damage_taken_enemy_defeated",
+	"move_fail_move_fail",
+	"trap_triggered_move_success",
+	"enemy_defeated_enemy_defeated",
+	"attack_miss_enemy_defeated",
+	"damage_taken_move_success",
+] as const;
+
+describe("SPEECH_SEQUENCE_VARIANTS", () => {
+	it.each(
+		PERSONALITIES,
+	)("性格 %s に全連続パターンのバリエーションが存在する（最低1つ）", (personality: Personality) => {
+		for (const key of sequenceKeys) {
+			const variants = SPEECH_SEQUENCE_VARIANTS[personality][key];
+			expect(variants).toBeDefined();
+			expect(variants?.length).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("全性格で同じキーセットを持つ", () => {
+		const firstKeys = Object.keys(
+			SPEECH_SEQUENCE_VARIANTS[PERSONALITIES[0]],
+		).sort();
+		for (const personality of PERSONALITIES.slice(1)) {
+			const keys = Object.keys(SPEECH_SEQUENCE_VARIANTS[personality]).sort();
+			expect(keys).toEqual(firstKeys);
+		}
+	});
+
+	it("全バリエーションが空文字列でない", () => {
+		for (const personality of PERSONALITIES) {
+			for (const key of sequenceKeys) {
+				const variants = SPEECH_SEQUENCE_VARIANTS[personality][key];
+				if (variants) {
+					for (const variant of variants) {
+						expect(variant.length).toBeGreaterThan(0);
+					}
+				}
+			}
 		}
 	});
 });

--- a/src/game/speechData.ts
+++ b/src/game/speechData.ts
@@ -392,3 +392,54 @@ export const SPEECH_VARIANTS: Record<
 		],
 	},
 } as const;
+
+/**
+ * 連続発話データ辞書
+ * キーは "直前イベント_現在イベント" 形式
+ * 未定義パターンは通常発話にフォールバック
+ */
+export const SPEECH_SEQUENCE_VARIANTS: Record<
+	Personality,
+	Partial<Record<`${SpeechEventType}_${SpeechEventType}`, readonly string[]>>
+> = {
+	brave: {
+		damage_taken_enemy_defeated: ["やり返したぞ！"],
+		move_fail_move_fail: ["また壁か…別の道を探す！"],
+		trap_triggered_move_success: ["今度は慎重に行くぞ"],
+		enemy_defeated_enemy_defeated: ["止まらないぞ！"],
+		attack_miss_enemy_defeated: ["今度は外さなかったな！"],
+		damage_taken_move_success: ["ここは一旦退くぞ"],
+	},
+	cautious: {
+		damage_taken_enemy_defeated: ["反撃成功、被害を取り戻した"],
+		move_fail_move_fail: ["マップの把握が甘いな…"],
+		trap_triggered_move_success: ["二度と同じ轍は踏まない"],
+		enemy_defeated_enemy_defeated: ["効率よく排除できている"],
+		attack_miss_enemy_defeated: ["修正完了、確実に仕留めた"],
+		damage_taken_move_success: ["被害を最小限に、退避する"],
+	},
+	cheerful: {
+		damage_taken_enemy_defeated: ["やられたらやり返す〜！"],
+		move_fail_move_fail: ["あはは、また壁だ〜！"],
+		trap_triggered_move_success: ["今度は気をつけるぞ〜"],
+		enemy_defeated_enemy_defeated: ["連勝だ〜！すごいすごい！"],
+		attack_miss_enemy_defeated: ["リベンジ成功〜！"],
+		damage_taken_move_success: ["いったん逃げるよ〜！"],
+	},
+	stoic: {
+		damage_taken_enemy_defeated: ["…借りは返した"],
+		move_fail_move_fail: ["…壁ばかりだ"],
+		trap_triggered_move_success: ["…二度はない"],
+		enemy_defeated_enemy_defeated: ["…続けて排除"],
+		attack_miss_enemy_defeated: ["…今度は当てた"],
+		damage_taken_move_success: ["…退く"],
+	},
+	curious: {
+		damage_taken_enemy_defeated: ["さっきの攻撃を分析して倒せた！"],
+		move_fail_move_fail: ["この壁の配置には法則がありそうだ"],
+		trap_triggered_move_success: ["罠の位置を覚えたぞ、次は大丈夫"],
+		enemy_defeated_enemy_defeated: ["連戦データが集まるな！"],
+		attack_miss_enemy_defeated: ["なるほど、こう当てればいいのか"],
+		damage_taken_move_success: ["距離を取って観察しよう"],
+	},
+} as const;


### PR DESCRIPTION
## 概要
- `SPEECH_SEQUENCE_VARIANTS` を追加し、直前イベントと現在イベントの組み合わせで文脈のある発話を実現
- 6パターン（被弾→撃破、連続壁衝突、罠→移動、連続撃破、空振り→撃破、被弾→退避）× 5性格分のデータを定義
- `addSpeechLog` に連続発話判定を追加（連続発話 > コンテキスト発話 > デフォルトの優先順位）
- シグネチャ変更なしのため、呼び出し元への影響なし
- speechData.test.ts / speech.test.ts にテストを追加

Closes #544

## テスト計画
- [ ] 連続パターン一致時に `SPEECH_SEQUENCE_VARIANTS` から選択される
- [ ] 連続パターン未定義時に通常発話にフォールバック
- [ ] `speechLog` が null（初回）の場合は通常発話
- [ ] 連続発話でも `eventType` は現在イベントが記録される
- [ ] 全5性格で連続発話が動作する
- [ ] 全性格に全連続パターンのバリエーションが存在（最低1つ）
- [ ] 全性格で同じキーセットを持つ
- [ ] 全バリエーションが空文字列でない
- [ ] `pnpm test:run` 全通過（1569テスト）
- [ ] `pnpm build` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)