### PR TITLE
feat: 発話UIをカード風デザインに変更

### DIFF
--- a/src/ui/characterCardRenderer.test.ts
+++ b/src/ui/characterCardRenderer.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { CharacterCardRenderer } from "./characterCardRenderer";
+import {
+	CharacterCardRenderer,
+	PERSONALITY_CARD_COLORS,
+} from "./characterCardRenderer";
 
 function getChildren(renderer: CharacterCardRenderer) {
 	const container = renderer.getContainer();
@@ -100,11 +103,11 @@ describe("CharacterCardRenderer", () => {
 	it("性格ごとにラベル色が切り替わる", () => {
 		const renderer = new CharacterCardRenderer();
 		const expectedColors: [Parameters<typeof renderer.render>[0], number][] = [
-			["brave", 0xca5a4a],
-			["cautious", 0x4a8aba],
-			["cheerful", 0xc8a840],
-			["stoic", 0x7a7a8a],
-			["curious", 0x8a6aba],
+			["brave", PERSONALITY_CARD_COLORS.brave.border],
+			["cautious", PERSONALITY_CARD_COLORS.cautious.border],
+			["cheerful", PERSONALITY_CARD_COLORS.cheerful.border],
+			["stoic", PERSONALITY_CARD_COLORS.stoic.border],
+			["curious", PERSONALITY_CARD_COLORS.curious.border],
 		];
 		for (const [personality, expectedColor] of expectedColors) {
 			renderer.render(personality, null);
@@ -116,9 +119,13 @@ describe("CharacterCardRenderer", () => {
 	it("性格変更時にラベル色が更新される", () => {
 		const renderer = new CharacterCardRenderer();
 		renderer.render("brave", null);
-		expect(getChildren(renderer).label.style.fill).toBe(0xca5a4a);
+		expect(getChildren(renderer).label.style.fill).toBe(
+			PERSONALITY_CARD_COLORS.brave.border,
+		);
 		renderer.render("cautious", null);
-		expect(getChildren(renderer).label.style.fill).toBe(0x4a8aba);
+		expect(getChildren(renderer).label.style.fill).toBe(
+			PERSONALITY_CARD_COLORS.cautious.border,
+		);
 	});
 
 	it("ツールチップが初期状態で非表示", () => {

--- a/src/ui/characterCardRenderer.ts
+++ b/src/ui/characterCardRenderer.ts
@@ -22,7 +22,7 @@ const CARD_BORDER_WIDTH = 2;
 const SPEECH_TEXT_COLOR = 0xeeeef0;
 const ICON_FONT_SIZE = 18;
 
-const PERSONALITY_CARD_COLORS: Record<
+export const PERSONALITY_CARD_COLORS: Record<
 	Personality,
 	{ bg: number; border: number }
 > = {


### PR DESCRIPTION
## 概要
- 発話UIの角丸半径を4px→8pxに変更し、手札カードと視覚的に統一
- 枠線幅を1px→2pxに変更してカードらしい太枠に
- 性格別アクセントカラー（背景・枠線）を導入（brave=赤、cautious=青、cheerful=黄、stoic=グレー、curious=紫）
- `drawRoundedRect`ヘルパー関数を使用して手札カードと同じ描画パターンに統一
- ラベルテキスト色を性格別枠線色と連動するよう変更
- 発話テキスト色をより明るい`0xeeeef0`に変更して可読性向上
- 背景透明度を0.9→0.95に微調整

Closes #555

## テスト計画
- [x] `pnpm format` — フォーマットチェック通過
- [x] `pnpm lint` — リントチェック通過
- [x] `pnpm build` — ビルド成功
- [x] `pnpm test:run` — 全97ファイル・1553テスト通過
- [ ] 各性格でゲームプレイし、発話カードの色が性格に応じて変化することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)