### PR TITLE
refactor: 敵位置検索を共通関数に集約

### DIFF
--- a/src/game/action.ts
+++ b/src/game/action.ts
@@ -27,6 +27,7 @@ import { incrementUseCount } from "./cardStats";
 import { applyDamageToEnemy } from "./combat";
 import { detectCombo, getComboBonus } from "./combo";
 import { markCardUsed } from "./deck";
+import { findEnemyAt, hasEnemyAt } from "./enemyUtils";
 import { revealAtPosition } from "./fogOfWar";
 import { isInBounds } from "./map";
 import { recordCardUsage } from "./playStats";
@@ -82,7 +83,7 @@ function canMove(state: GameState, direction: Direction): boolean {
 	}
 
 	// 敵がいるマス
-	if (state.enemies.some((e) => e.position.x === nx && e.position.y === ny)) {
+	if (hasEnemyAt(state.enemies, nx, ny)) {
 		return false;
 	}
 
@@ -212,9 +213,7 @@ function canAttack(
 	}
 
 	// 敵が存在するか
-	const enemy = state.enemies.find(
-		(e) => e.position.x === nx && e.position.y === ny,
-	);
+	const enemy = findEnemyAt(state.enemies, nx, ny);
 	if (!enemy) {
 		return { hit: false };
 	}
@@ -674,9 +673,7 @@ export function executeJump(
 	}
 
 	// 着地先に敵がいる
-	if (
-		next.enemies.some((e) => e.position.x === landX && e.position.y === landY)
-	) {
+	if (hasEnemyAt(next.enemies, landX, landY)) {
 		next = updateComboHistory(next, {
 			lastCardType: "jump",
 			lastDirection: null,

--- a/src/game/debugAction.ts
+++ b/src/game/debugAction.ts
@@ -6,6 +6,7 @@
 import type { GameState, Position } from "../types";
 import { applyDamageToEnemy } from "./combat";
 import { applyTileEffectWithDebug } from "./debugMiddleware";
+import { hasEnemyAt } from "./enemyUtils";
 import { isInBounds } from "./map";
 import { addActionLog, updatePlayer } from "./state";
 
@@ -48,9 +49,7 @@ export function executeDebugTeleport(
 		return { state, reachedStairs: false, gameOver: false };
 	}
 
-	const hasEnemy = state.enemies.some(
-		(e) => e.position.x === targetPos.x && e.position.y === targetPos.y,
-	);
+	const hasEnemy = hasEnemyAt(state.enemies, targetPos.x, targetPos.y);
 	if (hasEnemy) {
 		return { state, reachedStairs: false, gameOver: false };
 	}

--- a/src/game/enemyAi.ts
+++ b/src/game/enemyAi.ts
@@ -15,6 +15,7 @@ import { DIRECTION_DELTA } from "../types";
 import { checkEnrage, tryBossSkill, tryMinibossSkill } from "./bossSkill";
 import { applyEnemyDamageToPlayer, checkGameOver, isDefeated } from "./combat";
 import { DIRECTION_LABEL } from "./enemyAiAnalysis";
+import { hasEnemyAt } from "./enemyUtils";
 import { isInBounds } from "./map";
 import { bfsFirstStep } from "./pathfinding";
 import { isAdjacent, manhattanDistance } from "./positionUtils";
@@ -54,11 +55,7 @@ export function canEnemyMoveTo(
 		return false;
 	}
 
-	if (
-		state.enemies.some(
-			(e) => e.id !== enemy.id && e.position.x === nx && e.position.y === ny,
-		)
-	) {
+	if (hasEnemyAt(state.enemies, nx, ny, enemy.id)) {
 		return false;
 	}
 

--- a/src/game/enemyUtils.test.ts
+++ b/src/game/enemyUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { Enemy } from "../types";
+import { findEnemyAt, hasEnemyAt } from "./enemyUtils";
+
+const enemies: Enemy[] = [
+	{
+		id: "e1",
+		type: "normal",
+		position: { x: 2, y: 3 },
+		hp: 3,
+		maxHp: 3,
+	},
+	{
+		id: "e2",
+		type: "heavy",
+		position: { x: 5, y: 1 },
+		hp: 5,
+		maxHp: 5,
+	},
+];
+
+describe("findEnemyAt", () => {
+	it("指定座標に敵がいる場合その敵を返す", () => {
+		expect(findEnemyAt(enemies, 2, 3)).toBe(enemies[0]);
+	});
+
+	it("指定座標に敵がいない場合undefinedを返す", () => {
+		expect(findEnemyAt(enemies, 0, 0)).toBeUndefined();
+	});
+
+	it("空配列の場合undefinedを返す", () => {
+		expect(findEnemyAt([], 2, 3)).toBeUndefined();
+	});
+});
+
+describe("hasEnemyAt", () => {
+	it("指定座標に敵がいる場合trueを返す", () => {
+		expect(hasEnemyAt(enemies, 2, 3)).toBe(true);
+	});
+
+	it("指定座標に敵がいない場合falseを返す", () => {
+		expect(hasEnemyAt(enemies, 0, 0)).toBe(false);
+	});
+
+	it("excludeIdで指定した敵を除外して判定する", () => {
+		expect(hasEnemyAt(enemies, 2, 3, "e1")).toBe(false);
+	});
+
+	it("excludeIdで指定した以外の敵がいればtrueを返す", () => {
+		expect(hasEnemyAt(enemies, 5, 1, "e1")).toBe(true);
+	});
+});

--- a/src/game/enemyUtils.ts
+++ b/src/game/enemyUtils.ts
@@ -1,0 +1,34 @@
+/**
+ * 敵位置検索ユーティリティ
+ */
+
+import type { Enemy } from "../types";
+
+/**
+ * 指定座標にいる敵を返す
+ */
+export function findEnemyAt(
+	enemies: readonly Enemy[],
+	x: number,
+	y: number,
+): Enemy | undefined {
+	return enemies.find((e) => e.position.x === x && e.position.y === y);
+}
+
+/**
+ * 指定座標に敵がいるか判定する
+ * @param excludeId 除外する敵ID（自分自身を除く判定に使用）
+ */
+export function hasEnemyAt(
+	enemies: readonly Enemy[],
+	x: number,
+	y: number,
+	excludeId?: string,
+): boolean {
+	return enemies.some(
+		(e) =>
+			e.position.x === x &&
+			e.position.y === y &&
+			(excludeId === undefined || e.id !== excludeId),
+	);
+}

--- a/src/game/specialAttack.ts
+++ b/src/game/specialAttack.ts
@@ -7,6 +7,7 @@ import { ATTACK_EXTENDED_RANGE } from "../constants";
 import type { Direction, GameMap, GameState, Position } from "../types";
 import { DIRECTION_DELTA } from "../types";
 import { applyDamageToEnemy } from "./combat";
+import { findEnemyAt, hasEnemyAt } from "./enemyUtils";
 import { isInBounds } from "./map";
 import { addActionLog, setTile, updateEnemy } from "./state";
 
@@ -38,9 +39,7 @@ export function findAttackTarget(
 			return null;
 		}
 
-		const enemy = state.enemies.find(
-			(e) => e.position.x === nx && e.position.y === ny,
-		);
+		const enemy = findEnemyAt(state.enemies, nx, ny);
 		if (enemy) {
 			return { enemyId: enemy.id, position: { x: nx, y: ny } };
 		}
@@ -84,9 +83,7 @@ export function applyPierce(
 			break;
 		}
 
-		const enemy = state.enemies.find(
-			(e) => e.position.x === cx && e.position.y === cy,
-		);
+		const enemy = findEnemyAt(state.enemies, cx, cy);
 		if (enemy) {
 			const next = addActionLog(state, "貫通！", "system");
 			const result = applyDamageToEnemy(next, enemy.id, overkill, attackCardId);
@@ -142,8 +139,7 @@ function canKnockbackTo(
 		return false;
 	if (state.player.position.x === x && state.player.position.y === y)
 		return false;
-	if (state.enemies.some((e) => e.position.x === x && e.position.y === y))
-		return false;
+	if (hasEnemyAt(state.enemies, x, y)) return false;
 	return true;
 }
 
@@ -226,9 +222,7 @@ export function executeShockwave(
 			crackedWallDestroyed: true,
 		};
 	}
-	const frontEnemy = state.enemies.find(
-		(e) => e.position.x === frontPos.x && e.position.y === frontPos.y,
-	);
+	const frontEnemy = findEnemyAt(state.enemies, frontPos.x, frontPos.y);
 	if (!frontEnemy) {
 		return {
 			state,
@@ -255,9 +249,7 @@ export function executeShockwave(
 		)
 			continue;
 
-		const enemy = next.enemies.find(
-			(e) => e.position.x === pos.x && e.position.y === pos.y,
-		);
+		const enemy = findEnemyAt(next.enemies, pos.x, pos.y);
 		if (!enemy) continue;
 
 		const result = applyDamageToEnemy(next, enemy.id, damage, attackCardId);


### PR DESCRIPTION
## 概要
- `findEnemyAt(enemies, x, y)` / `hasEnemyAt(enemies, x, y)` を `enemyUtils.ts` に定義
- `action.ts`, `enemyAi.ts`, `specialAttack.ts`, `debugAction.ts` の重複する敵位置検索パターンを共通関数に置換
- `hasEnemyAt` に `excludeId` オプション引数を追加し、自分自身を除外する判定にも対応
- ユニットテスト追加

Closes #596

## テスト計画
- [x] `findEnemyAt` / `hasEnemyAt` のユニットテスト追加・通過
- [x] 既存テスト全通過（1732テスト）
- [x] ビルド成功
- [x] E2Eテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)