### PR TITLE
refactor: UIアニメーション定数のマジックナンバー排除

### DIFF
--- a/src/ui/handRenderer.ts
+++ b/src/ui/handRenderer.ts
@@ -72,8 +72,17 @@ const CONSUME_FLY_DURATION = 200;
 /** 消費アニメーション：飛行先Y座標（相対） */
 const CONSUME_FLY_TARGET_Y = -70;
 
+/** 消費アニメーション：縮小後スケール */
+const CONSUME_SHRINK_SCALE = 0.3;
+
 /** 消費アニメーション：パーティクル数 */
 const CONSUME_PARTICLE_COUNT = 12;
+
+/** 配りアニメーション：初期スケール */
+const DEAL_INITIAL_SCALE = 0.5;
+
+/** ドラッグ中カードの不透明度 */
+const DRAG_OPACITY = 0.8;
 
 /**
  * カード内のクリック位置から方向を判定
@@ -324,7 +333,7 @@ export class HandRenderer {
 				cardContainer.x = DECK_OFFSET_X;
 				cardContainer.y = DECK_OFFSET_Y;
 				cardContainer.alpha = 0;
-				cardContainer.scale.set(0.5);
+				cardContainer.scale.set(DEAL_INITIAL_SCALE);
 
 				// 各カードに少しずつディレイを入れて順番に配る
 				const delay = animationIndex * DEAL_ANIMATION_DELAY;
@@ -578,7 +587,12 @@ export class HandRenderer {
 			const flyTargetY = container.y + CONSUME_FLY_TARGET_Y;
 			await tween(
 				container,
-				{ y: flyTargetY, scaleX: 0.3, scaleY: 0.3, alpha: 0 },
+				{
+					y: flyTargetY,
+					scaleX: CONSUME_SHRINK_SCALE,
+					scaleY: CONSUME_SHRINK_SCALE,
+					alpha: 0,
+				},
 				{ duration: CONSUME_FLY_DURATION, easing: Easing.easeOut },
 			);
 			// フェーズ2: パーティクル放出（fire-and-forget）
@@ -804,7 +818,7 @@ export class HandRenderer {
 				child.x = this.dragCurrentX - containerGlobalPos.x - CARD_WIDTH / 2;
 				child.y = -DRAG_LIFT;
 				child.zIndex = 1;
-				child.alpha = 0.8;
+				child.alpha = DRAG_OPACITY;
 			} else {
 				// 他のカード: 挿入位置に応じてスライド
 				const actualIndex = this.getActualIndex(child);

--- a/src/ui/rewardScreen.ts
+++ b/src/ui/rewardScreen.ts
@@ -47,10 +47,16 @@ const ACQUIRE_SCALE_DURATION = 200;
 const ACQUIRE_SHRINK_DURATION = 300;
 const ACQUIRE_PARTICLE_COUNT = 20;
 
+/** カード取得アニメーション：拡大スケール */
+const ACQUIRE_EXPAND_SCALE = 1.15;
+
 /** カード除去アニメーション定数 */
 const REMOVE_FADE_DURATION = 400;
 const REMOVE_PARTICLE_COLORS = [0xff4444, 0xff6644, 0xcc2222];
 const REMOVE_PARTICLE_COUNT = 15;
+
+/** カード除去アニメーション：縮小スケール */
+const REMOVE_SHRINK_SCALE = 0.8;
 
 /** グリッドレイアウト定数 */
 const GRID_COLUMNS = 4;
@@ -803,7 +809,7 @@ export class RewardScreen {
 
 		await tween(
 			cardContainer,
-			{ scaleX: 1.15, scaleY: 1.15 },
+			{ scaleX: ACQUIRE_EXPAND_SCALE, scaleY: ACQUIRE_EXPAND_SCALE },
 			{ duration: ACQUIRE_SCALE_DURATION, easing: Easing.easeOutBack },
 		);
 
@@ -843,7 +849,7 @@ export class RewardScreen {
 
 		await tween(
 			itemContainer,
-			{ alpha: 0, scaleX: 0.8, scaleY: 0.8 },
+			{ alpha: 0, scaleX: REMOVE_SHRINK_SCALE, scaleY: REMOVE_SHRINK_SCALE },
 			{ duration: REMOVE_FADE_DURATION, easing: Easing.easeInOut },
 		);
 	}


### PR DESCRIPTION
## 概要
- `handRenderer.ts`: インラインの `0.5`（配り初期スケール）、`0.3`（消費縮小スケール）、`0.8`（ドラッグ不透明度）を名前付き定数 `DEAL_INITIAL_SCALE`、`CONSUME_SHRINK_SCALE`、`DRAG_OPACITY` に抽出
- `rewardScreen.ts`: インラインの `1.15`（取得拡大スケール）、`0.8`（除去縮小スケール）を名前付き定数 `ACQUIRE_EXPAND_SCALE`、`REMOVE_SHRINK_SCALE` に抽出

Closes #601

## テスト計画
- [x] `pnpm lint` 通過
- [x] `pnpm build` 成功
- [x] `pnpm test:run` 全テスト通過（1737件）
- [x] `pnpm test:e2e` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)